### PR TITLE
Add 30 more Lovecraftian species (40 total) and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,51 +8,132 @@ Built on the [stdpopsim](https://github.com/popsim-consortium/stdpopsim) framewo
 for creatures from H.P. Lovecraft's Cthulhu Mythos. All models use realistic population
 genetic parameters and are fully simulatable with `msprime` and `SLiM`.
 
+**40 species, 80 demographic models.**
+
 ## Available Species
 
-| ID | Species | Common Name | Pop Size | Gen Time |
-|--------|-------------------------------|--------------------------|----------|----------|
-| CthGre | *Cthulhu greatoldone* | Great Cthulhu | 500 | 10,000 yr |
-| NyaAza | *Nyarlathotep azathothspawn* | Crawling Chaos | 1,000 | 1 yr |
-| ShoNig | *Shoggoth nigrumplasma* | Shoggoth | 100,000 | 0.5 yr |
-| YogSot | *Yogsothoth dimensionalis* | The Key and the Gate | 10 | 100,000 yr |
-| DagHyd | *Dagonus hydridae* | Deep One | 50,000 | 100 yr |
-| MiGFun | *Migo fungoides* | Fungi from Yuggoth | 500,000 | 5 yr |
-| HasKin | *Hastur carcosensis* | King in Yellow | 2,000 | 50 yr |
-| EldThi | *Elderium antarcticae* | Elder Thing | 10,000 | 1,000 yr |
-| GhoFee | *Ghoulish necrophagus* | Ghoul | 30,000 | 20 yr |
-| BybWor | *Byakhee voidwing* | Byakhee | 200,000 | 10 yr |
+### Outer Gods & Great Old Ones
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| AzaPri | *Azathoth primordia* | Blind Idiot God | 1 | 1M yr | 2 |
+| CthGre | *Cthulhu greatoldone* | Great Cthulhu | 500 | 10K yr | 4 |
+| DagGod | *Dagonus maximus* | Father Dagon | 50 | 50K yr | 4 |
+| HasKin | *Hastur carcosensis* | King in Yellow | 2,000 | 50 yr | 2 |
+| NyaAza | *Nyarlathotep azathothspawn* | Crawling Chaos | 1,000 | 1 yr | 2 |
+| ShbNig | *Shubniggurath fertilitas* | Black Goat of the Woods | 100,000 | 25 yr | 2 |
+| TsaGod | *Tsathoggua somnolentis* | Tsathoggua | 100 | 50K yr | 2 |
+| YogSot | *Yogsothoth dimensionalis* | The Key and the Gate | 10 | 100K yr | 2 |
+| ChaFau | *Chaugnarus faugnis* | Chaugnar Faugn | 200 | 10K yr | 2 |
+
+### Servitor Races & Engineered Species
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| ShoNig | *Shoggoth nigrumplasma* | Shoggoth | 100,000 | 0.5 yr | 6 |
+| StarSp | *Starspawn cthulhidae* | Star-Spawn of Cthulhu | 10,000 | 5K yr | 4 |
+| DarYou | *Obscurus silvanus* | Dark Young | 35,000 | 50 yr | 3 |
+| ForSpa | *Informis generatus* | Formless Spawn | 25,000 | 10 yr | 2 |
+| HunTin | *Venator obscurus* | Hunting Horror | 15,000 | 20 yr | 2 |
+| FirVam | *Igneus vampirus* | Fire Vampire | 1M | 0.01 yr | 1 |
+| BybWor | *Byakhee voidwing* | Byakhee | 200,000 | 10 yr | 2 |
+
+### Ancient Civilizations
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| EldThi | *Elderium antarcticae* | Elder Thing | 10,000 | 1K yr | 2 |
+| YitGre | *Yithianus temporalis* | Great Race of Yith | 50,000 | 500 yr | 2 |
+| FlyPol | *Polypus volantis* | Flying Polyp | 20,000 | 2K yr | 2 |
+| SerHum | *Serpentis valusiensis* | Serpent Person | 40,000 | 50 yr | 2 |
+| MiGFun | *Migo fungoides* | Fungi from Yuggoth | 500,000 | 5 yr | 2 |
+
+### Amphibious & Aquatic
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| DagHyd | *Dagonus hydridae* | Deep One | 50,000 | 100 yr | 2 |
+| ColOos | *Chromatis extraspatiala* | Colour Out of Space | 10,000 | 0.1 yr | 1 |
+
+### Subterranean Horrors
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| GhoFee | *Ghoulish necrophagus* | Ghoul | 30,000 | 20 yr | 2 |
+| GugsUn | *Gugus underworldis* | Gug | 25,000 | 30 yr | 2 |
+| GhaShe | *Ghastus cavernicola* | Ghast | 80,000 | 3 yr | 2 |
+| DhoGno | *Dholos subterraneus* | Dhole | 15,000 | 200 yr | 2 |
+| WamUnd | *Degeneratus subterraneus* | Wamp | 20,000 | 10 yr | 2 |
+
+### Dreamlands Creatures
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| NigMan | *Nightgauntus mantaformis* | Nightgaunt | 75,000 | 5 yr | 2 |
+| SanDre | *Shantakus dreamlandis* | Shantak | 60,000 | 15 yr | 2 |
+| MooFun | *Lunaris bestialis* | Moon-Beast | 45,000 | 8 yr | 2 |
+| ZooGul | *Zoogus sylvaticus* | Zoog | 500,000 | 2 yr | 2 |
+| CatUlt | *Felis ultharensis* | Cat of Ulthar | 100,000 | 5 yr | 2 |
+| LenSpi | *Araneus lengensis* | Leng Spider | 20,000 | 10 yr | 2 |
+
+### Interdimensional & Temporal
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| HouFir | *Houndus tindalosi* | Hound of Tindalos | 5,000 | 500 yr | 2 |
+| DimSha | *Dimensius shambleris* | Dimensional Shambler | 3,000 | 100 yr | 2 |
+
+### Arctic & Desert
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| GnpKeh | *Gnophkehus arcticus* | Gnoph-Keh | 12,000 | 40 yr | 2 |
+| SanDwl | *Arenicola abyssalis* | Sand Dweller | 40,000 | 15 yr | 2 |
+
+### Human-Adjacent Horrors
+
+| ID | Species | Common Name | Pop Size | Gen Time | Ploidy |
+|--------|-------------------------------|--------------------------|----------|----------|--------|
+| TsaCho | *Tsathoggua choriensis* | Tcho-Tcho | 70,000 | 25 yr | 2 |
+| RatThi | *Rattus magicus* | Rat-Thing | 50,000 | 1 yr | 2 |
 
 ## Quick Start
 
 ```python
 import stdpopsim
 
-# Get the Deep Ones species
-species = stdpopsim.get_species("DagHyd")
+# Get the Shoggoth species (hexaploid engineered servitors)
+species = stdpopsim.get_species("ShoNig")
 
-# Use the Innsmouth Decline demographic model
-model = species.get_demographic_model("InnsmouthDecline_1M27")
+# Use the Antarctic Revolt demographic model
+model = species.get_demographic_model("AntarcticRevolt_1D31")
 
-# Set up a contig (chromosome 1, 10Mb chunk)
-contig = species.get_contig("1", length=10_000_000)
+# Set up a generic contig of 100kb
+contig = species.get_contig(length=100_000)
 
 # Simulate with msprime
 engine = stdpopsim.get_engine("msprime")
-ts = engine.simulate(model, contig, {"DeepOnes": 50})
+ts = engine.simulate(model, contig, samples={"Antarctic": 20}, seed=42)
+
+print(f"Trees: {ts.num_trees}, Mutations: {ts.num_mutations}")
+```
+
+## CLI Usage
+
+```bash
+# List all available species
+stdvoidsim --help
+
+# Simulate 10 Deep One samples under the Innsmouth Decline model
+stdvoidsim DagHyd -d InnsmouthDecline_1M27 -o deep_ones.trees -L 100000 DeepOnes:10
+
+# Simulate Shoggoth rebellion scenario
+stdvoidsim ShoNig -d AntarcticRevolt_1D31 -o shoggoths.trees -L 50000 Antarctic:20
 ```
 
 ## Installation
 
 ```bash
-pip install stdvoidsim
-```
-
-Or for development:
-
-```bash
-git clone https://github.com/your-org/stdvoidsim.git
-cd stdvoidsim
 pip install -e .
 ```
 

--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -4,10 +4,9 @@
 Catalog
 =======
 
-With ``stdpopsim``, you can run simulations from a number of demographic models
-that were implemented from published demographic histories. These models have been
-rigorously checked and tested by multiple people, so you can rest easy knowing that
-your simulations are reproducible and bug-free!
+With ``stdvoidsim``, you can run simulations from a number of demographic models
+for Lovecraftian entities from the Cthulhu Mythos. Each species has made-up but
+population-genetically plausible parameters and demographic histories.
 
 This catalog shows you all of the possible options that you can use to configure
 your simulation.
@@ -15,100 +14,129 @@ It is organised around a number of choices that you'll need to make about the
 :class:`.Species` you wish to simulate:
 
 1. Which **chromosome** (:class:`.Genome` object)?
-2. Which **recombination/genetic map** (:class:`.GeneticMap` object)?
-3. Which **model of demographic history** (:class:`.DemographicModel` object)?
-4. Which **distribution of fitness effects** (:class:`.DFE` object) within
-5. which **annotation track** (:class:`.Annotation` object)?
+2. Which **model of demographic history** (:class:`.DemographicModel` object)?
 
-For instance, suppose you are interested in simulating modern human samples of
-
-1. chromosome 22, using
-2. the HapMapII genetic map, under
-3. a 3-population Out-of-Africa model, with
-4. background selection acting within
-5. exons from the Ensembl Havana 104 annotations.
-
-The following command simulates 2 samples from each of the three populations,
-(named YRI, CEU, and CHB) and saves the output to a file called ``test.trees``:
+For instance, suppose you are interested in simulating Deep One samples under
+an Innsmouth Decline demographic model:
 
 .. code-block:: console
 
-    $ stdpopsim -e slim HomSap -c chr22 -o test.trees -g HapMapII_GRCh38 \
-    $    --dfe Gamma_K17 --dfe-annotation ensembl_havana_104_exons \
-    $    -d OutOfAfrica_3G09 YRI:2 CEU:2 CHB:2
+    $ stdvoidsim DagHyd -d InnsmouthDecline_1M27 -o deep_ones.trees -L 100000 DeepOnes:10
 
 
-(To learn more about using ``stdpopsim`` via the command-line, read our
-:ref:`tutorial <sec_cli_tute>` about it.)
+Outer Gods & Great Old Ones
+===========================
 
-Are there other well-known organisms, genetic maps or models that
-you'd like to see in ``stdpopsim``? Head to our :ref:`sec_development`
-page to learn about the process for adding new items to the catalog.
-Then, if you feel ready, make an issue on our
-`GitHub page <https://github.com/popgensims/stdpopsim/issues>`_.
+.. speciescatalog:: AzaPri
 
-.. speciescatalog:: AedAeg
+.. speciescatalog:: CthGre
 
-.. speciescatalog:: AnaPla
+.. speciescatalog:: ChaFau
 
-.. speciescatalog:: AnoCar
+.. speciescatalog:: DagGod
 
-.. speciescatalog:: AnoGam
+.. speciescatalog:: HasKin
 
-.. speciescatalog:: ApiMel
+.. speciescatalog:: NyaAza
 
-.. speciescatalog:: AraTha
+.. speciescatalog:: ShbNig
 
-.. speciescatalog:: BosTau
+.. speciescatalog:: TsaGod
 
-.. speciescatalog:: CaeEle
+.. speciescatalog:: YogSot
 
-.. speciescatalog:: CanFam
+Servitor Races & Engineered Species
+====================================
 
-.. speciescatalog:: ChlRei
+.. speciescatalog:: BybWor
 
-.. speciescatalog:: DroMel
+.. speciescatalog:: DarYou
 
-.. speciescatalog:: DroSec
+.. speciescatalog:: FirVam
 
-.. speciescatalog:: EscCol
+.. speciescatalog:: ForSpa
 
-.. speciescatalog:: GasAcu
+.. speciescatalog:: HunTin
 
-.. speciescatalog:: GorGor
+.. speciescatalog:: ShoNig
 
-.. speciescatalog:: HelAnn
+.. speciescatalog:: StarSp
 
-.. speciescatalog:: HelMel
+Ancient Civilizations
+=====================
 
-.. speciescatalog:: HomSap
+.. speciescatalog:: EldThi
 
-.. speciescatalog:: MusMus
+.. speciescatalog:: FlyPol
 
-.. speciescatalog:: OrySat
+.. speciescatalog:: MiGFun
 
-.. speciescatalog:: PanTro
+.. speciescatalog:: SerHum
 
-.. speciescatalog:: PapAnu
+.. speciescatalog:: YitGre
 
-.. speciescatalog:: PhoSin
+Amphibious & Aquatic
+====================
 
-.. speciescatalog:: PonAbe
+.. speciescatalog:: ColOos
 
-.. speciescatalog:: RatNor
+.. speciescatalog:: DagHyd
 
-.. speciescatalog:: StrAga
+Subterranean Horrors
+====================
 
-.. speciescatalog:: SusScr
+.. speciescatalog:: DhoGno
+
+.. speciescatalog:: GhaShe
+
+.. speciescatalog:: GhoFee
+
+.. speciescatalog:: GugsUn
+
+.. speciescatalog:: WamUnd
+
+Dreamlands Creatures
+====================
+
+.. speciescatalog:: CatUlt
+
+.. speciescatalog:: LenSpi
+
+.. speciescatalog:: MooFun
+
+.. speciescatalog:: NigMan
+
+.. speciescatalog:: SanDre
+
+.. speciescatalog:: ZooGul
+
+Interdimensional & Temporal
+===========================
+
+.. speciescatalog:: DimSha
+
+.. speciescatalog:: HouFir
+
+Arctic & Desert
+===============
+
+.. speciescatalog:: GnpKeh
+
+.. speciescatalog:: SanDwl
+
+Human-Adjacent Horrors
+======================
+
+.. speciescatalog:: RatThi
+
+.. speciescatalog:: TsaCho
 
 Generic models
 ==============
 
-In addition to the species-specific models listed in this catalog, ``stdpopsim`` offers
+In addition to the species-specific models listed in this catalog, ``stdvoidsim`` offers
 a number of generic demographic models that can be run with any species.
 These are described in more detail in the :ref:`API <sec_api_generic_models>`.
-Simulations using these generic models must be run via the Python interface; see our
-:ref:`Python tutorial <sec_python_tute>` to learn how to do this.
 
  - :meth:`stdpopsim.PiecewiseConstantSize`
  - :meth:`stdpopsim.IsolationWithMigration`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,11 @@
-.. stdpopsim documentation index file, created by
-   sphinx-quickstart on Sun Feb  3 17:26:38 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. stdvoidsim documentation index file
 
-Welcome to stdpopsim's documentation!
-=====================================
+Welcome to stdvoidsim's documentation!
+=======================================
+
+``stdvoidsim`` is a library of population genetic simulation models for
+Lovecraftian entities and eldritch horrors, built on the
+`stdpopsim <https://github.com/popsim-consortium/stdpopsim>`_ framework.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -4,16 +4,15 @@
 Introduction
 ============
 
-.. note:: This documentation is incomplete and under development. If
-    you would like to help, please open an issue or pull request at
-    `GitHub <https://github.com/popgensims/stdpopsim>`_.
+This is the documentation for ``stdvoidsim``, a library of population
+genetic simulation models for Lovecraftian entities and eldritch horrors.
 
-This is the documentation for ``stdpopsim``, the standard library for population
-genetic simulation models.
+``stdvoidsim`` is a fork of ``stdpopsim`` that replaces real-world species with
+40 fictional creatures from H.P. Lovecraft's Cthulhu Mythos. Each species has
+made-up but population-genetically plausible genomes and demographic models
+suitable for testing inference methods on non-standard scenarios.
 
-We designed ``stdpopsim`` to make it easier for you to run reproducible, bug-free
-simulations of genetic datasets from published demographic histories.
-Under the hood, ``stdpopsim`` relies on
+Under the hood, ``stdvoidsim`` relies on
 `msprime <https://tskit.dev/software/msprime.html>`_ and
 `SLiM 4 <https://messerlab.org/slim/>`_ to generate sample datasets in the
 `tree sequence <https://tskit.dev/learn/>`_ format.
@@ -22,158 +21,34 @@ Under the hood, ``stdpopsim`` relies on
 First steps
 -----------
 
- - Head to the :ref:`Installation <sec_installation>` page to get ``stdpopsim`` installed
+ - Head to the :ref:`Installation <sec_installation>` page to get ``stdvoidsim`` installed
    on your computer.
 
- - Skim the :ref:`Catalog <sec_catalog>` to see what simulations are currently supported
-   by ``stdpopsim``.
+ - Skim the :ref:`Catalog <sec_catalog>` to see what eldritch simulations are currently
+   supported by ``stdvoidsim``.
 
- - Read the :ref:`Tutorials <sec_tutorial>` to see some examples of ``stdpopsim`` in
+ - Read the :ref:`Tutorials <sec_tutorial>` to see some examples of ``stdvoidsim`` in
    action.
 
-
-Getting involved
-----------------
-
-``stdpopsim`` **is a community effort, and we welcome YOU to join us!**
-
-Are there other features, models or organisms that you'd like to see in ``stdpopsim``?
-This software is maintained by the PopSim Consortium,
-an open, global community of scientists and developers who are working together to improve
-standards for benchmarking and testing in population genetics.
-You can get into contact with the ``stdpopsim`` community by subscribing to our `email list
-serve <https://lists.uoregon.edu/mailman/listinfo/popgen_benchmark>`_
-and by creating and commenting on
-Github `issues <http://github.com/popgensims/stdpopsim/issues>`_.
-There is a lot of chatter through
-Github, and we’ve been building code
-there cooperatively. If you are interested in joining us please read our
-`code of conduct <https://github.com/popsim-consortium/stdpopsim/blob/main/CODE_OF_CONDUCT.md>`_.
-A particular goal of this project is to build a diverse and supportive community,
-and so we especially encourage individuals from underrepresented groups in popgen to join.
-A primary goal of PopSim Consortium is to be inclusive to the largest number of contributors,
-with the most varied and diverse backgrounds possible. As such, we are committed to providing a
-friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability,
-ethnicity, socioeconomic status, and religion (or lack thereof).
-Being a member of the Consortium can provide a valuable avenue for career development, through
-building networks, contributing to papers and code, as well as through learning programing standards
-and best practices.
-
-For further details read the :ref:`Development <sec_development>` page to find out how you can join us.
 
 Citations
 ---------
 
-If you use ``stdpopsim`` in your work, please cite our
-`original manuscript <https://doi.org/10.7554/eLife.54967>`__,
-`adding-species manuscript <https://doi.org/10.1101/2022.10.29.514266>`__, and/or
-`selection manuscript <https://doi.org/10.1101/2025.03.23.644823>`__:
+``stdvoidsim`` is built on the ``stdpopsim`` framework. If you use the simulation
+framework, please cite:
 
-  - Jeffrey R Adrion, Christopher B Cole, Noah Dukler, Jared G Galloway,
-    Ariella L Gladstein, Graham Gower, Christopher C Kyriazis, Aaron P Ragsdale,
-    Georgia Tsambos, Franz Baumdicker, Jedidiah Carlson, Reed A Cartwright,
-    Arun Durvasula, Ilan Gronau, Bernard Y Kim, Patrick McKenzie,
-    Philipp W Messer, Ekaterina Noskova, Diego Ortega-Del Vecchyo, Fernando Racimo,
-    Travis J Struck, Simon Gravel, Ryan N Gutenkunst, Kirk E Lohmeuller,
-    Peter L Ralph, Daniel R Schrider, Adam Siepel, Jerome Kelleher, Andrew D Kern (2020),
+  - Jeffrey R Adrion et al. (2020),
     *A community-maintained standard library of population genetic models*,
     eLife 9:e54967; doi: https://doi.org/10.7554/eLife.54967
 
-  - M Elise Lauterbur, Maria Izabel A Cavassim, Ariella L Gladstein, Graham Gower,
-    Nathaniel S Pope, Georgia Tsambos, Jeff Adrion, Saurabh Belsare, Arjun Biddanda,
-    Victoria Caudill, Jean Cury, Ignacio Echevarria, Benjamin C Haller, Ahmed R Hasan,
-    Xin Huang, Leonardo Nicola Martin Iasi, Ekaterina Noskova, Jana Obšteter,
-    Vitor Antonio Corrêa Pavinato, Alice Pearson, David Peede, Manolo F Perez,
-    Murillo F Rodrigues, Chris C R Smith, Jeffrey P Spence, Anastasia Teterina,
-    Silas Tittes, Per Unneberg, Juan Manuel Vazquez, Ryan K Waples, Anthony Wilder Wohns,
-    Yan Wong, Franz Baumdicker, Reed A Cartwright, Gregor Gorjanc, Ryan N Gutenkunst,
-    Jerome Kelleher, Andrew D Kern, Aaron P Ragsdale, Peter L Ralph, Daniel R Schrider,
-    Ilan Gronau (2023)
+  - M Elise Lauterbur et al. (2023),
     *Expanding the stdpopsim species catalog, and lessons learned for realistic genome simulations*,
     eLife 12:RP84874; doi: https://doi.org/10.7554/eLife.84874
-
-  - Graham Gower, Nathaniel S Pope, Murillo F Rodrigues, Silas Tittes, Linh N Tran,
-    Ornob Alam, Maria Izabel A Cavassim, Peter D Fields, Benjamin C Haller, Xin Huang,
-    Ben Jeffrey, Kevin Korfmann, Christopher C Kyriazis, Jiseon Min, Inés Rebollo,
-    Clara T Rehmann, Scott T Small, Chris C R Smith, Georgia Tsambos, Yan Wong,
-    Yu Zhang, Christian D Huber, Gregor Gorjanc, Aaron P Ragsdale, Ilan Gronau,
-    Ryan N Gutenkunst, Jerome Kelleher, Kirk E Lohmueller, Daniel R Schrider,
-    Peter L Ralph, Andrew D Kern
-    *Accessible, realistic genome simulation with selection using stdpopsim*,
-    Molecular Biology and Evolution msaf236; doi: https://doi.org/10.1093/molbev/msaf236
-
-Bibtex entries for these manuscripts are::
-
-    @article{adrion2020community,
-        article_type = {journal},
-        title = {A community-maintained standard library of population genetic models},
-        author = {Adrion, Jeffrey R and Cole, Christopher B and Dukler, Noah and Galloway, Jared
-            G and Gladstein, Ariella L and Gower, Graham and Kyriazis, Christopher C and Ragsdale,
-            Aaron P and Tsambos, Georgia and Baumdicker, Franz and Carlson, Jedidiah and Cartwright,
-            Reed A and Durvasula, Arun and Gronau, Ilan and Kim, Bernard Y and McKenzie, Patrick and
-            Messer, Philipp W and Noskova, Ekaterina and Ortega-Del Vecchyo, Diego and Racimo,
-            Fernando and Struck, Travis J and Gravel, Simon and Gutenkunst, Ryan N and Lohmueller,
-            Kirk E and Ralph, Peter L and Schrider, Daniel R and Siepel, Adam and Kelleher, Jerome
-            and Kern, Andrew D},
-        editor = {Coop, Graham and Wittkopp, Patricia J and Novembre, John and Sethuraman, Arun
-            and Mathieson, Sara},
-        volume = 9,
-        year = 2020,
-        month = {jun},
-        pub_date = {2020-06-23},
-        pages = {e54967},
-        citation = {eLife 2020;9:e54967},
-        doi = {10.7554/eLife.54967},
-        url = {https://doi.org/10.7554/eLife.54967},
-        keywords = {simulation, reproducibility, open source},
-        journal = {eLife},
-        issn = {2050-084X},
-        publisher = {eLife Sciences Publications, Ltd},
-    }
-
-    @article{lauterbur2023expanding,
-        title={Expanding the stdpopsim species catalog, and lessons learned for realistic genome simulations},
-        author = {Lauterbur, M Elise and Cavassim, Maria Izabel A and Gladstein, Ariella L and Gower, Graham and
-           Pope, Nathaniel S and Tsambos, Georgia and Adrion, Jeffrey R and Belsare, Saurabh and Biddanda, Arjun and
-           Caudill, Victoria and Cury, Jean and Echevarria, Ignacio and Haller, Benjamin C and Hasan, Ahmed R and
-           Huang, Xin and Iasi,  Leonardo Nicola Martin and Noskova, Ekaterina and Ob{\v{s}}teter, Jana and
-           Pavinato, Vitor Antonio Corr{\^{e}}a and Pearson, Alice and Peede, David and Perez, Manolo F and
-           Rodrigues, Murillo F and Smith, Chris C R and Spence, Jeffrey P and Teterina, Anastasia and
-           Tittes, Silas and Unneberg, Per and Vazquez, Juan Manuel and Waples, Ryan K and Wohns, Anthony Wilder and
-           Wong, Yan and Baumdicker, Franz and Cartwright, Reed A and Gorjanc, Gregor and Gutenkunst, Ryan N and
-           Kelleher, Jerome and Kern, Andrew D and Ragsdale, Aaron P and Ralph, Peter L and Schrider, Daniel R and
-           Gronau, Ilan},
-        doi = {10.7554/elife.84874},
-        url = {https://doi.org/10.7554/elife.84874},
-        journal = {eLife},
-        volume={12},
-        pages={RP84874},
-        year = 2023,
-        month = {may},
-        publisher = {{eLife} Sciences Publications, Ltd},
-    }
-
-    @article{gower2025accessible,
-        title = {Accessible, realistic genome simulation with selection using stdpopsim},
-        author = {Gower, Graham and Pope, Nathaniel S and Rodrigues, Murillo F and Tittes, Silas and
-            Tran, Linh N and Alam, Ornob and Cavassim, Maria Izabel A and Fields, Peter D and
-            Haller, Benjamin C and Huang, Xin and Jeffrey, Ben and Korfmann, Kevin and
-            Kyriazis, Christopher C and Min, Jiseon and Rebollo, In{\'e}s and Rehmann, Clara T and
-            Small, Scott T and Smith, Chris C R and Tsambos, Georgia and Wong, Yan and Zhang, Yu and
-            Huber, Christian D and Gorjanc, Gregor and Ragsdale, Aaron P and Gronau, Ilan and
-            Gutenkunst, Ryan N and Kelleher, Jerome and Lohmueller, Kirk E and Schrider, Daniel R and
-            Ralph, Peter L and Kern, Andrew D},
-        year = {2025},
-        pages = {msaf236},
-        doi = {10.1093/molbev/msaf236},
-        URL = {https://doi.org/10.1093/molbev/msaf236},
-        journal = {Molecular Biology and Evolution}
-    }
 
 
 Licence and usage
 -----------------
 
-``stdpopsim`` is available under the GPLv3 public license.
+``stdvoidsim`` is available under the GPLv3 public license.
 The terms of this license can be read
 `here <https://www.gnu.org/licenses/gpl-3.0.en.html>`_.

--- a/stdpopsim/catalog/AzaPri/__init__.py
+++ b/stdpopsim/catalog/AzaPri/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Azathoth primordia
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/AzaPri/demographic_models.py
+++ b/stdpopsim/catalog/AzaPri/demographic_models.py
@@ -1,0 +1,118 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("AzaPri")
+
+_nucleus_pop = stdpopsim.Population(
+    id="Nucleus", description="The nuclear chaos at the center of infinity"
+)
+_fragment_pop = stdpopsim.Population(
+    id="Fragment", description="Fragmentary emanations cast into the void"
+)
+
+def _nuclear_pulsation():
+    id = "NuclearPulsation_1S22"
+    description = "Pulsating single population model of Azathoth"
+    long_description = """
+        A single population model representing the pulsating nuclear chaos
+        of Azathoth at the center of ultimate chaos. The entity periodically
+        fragments and reconverges. Three epochs: current singularity (N=1),
+        brief fragmentation 10 generations ago (N=100), ancient unified
+        chaos 100 generations ago (N=1).
+    """
+    populations = [_nucleus_pop]
+    citations = [
+        stdpopsim.Citation(
+            author="The Daemon Sultan Cult",
+            year=1922,
+            doi="https://doi.org/10.1666/void.azathoth.dem1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        )
+    ]
+    generation_time = _species.generation_time
+    mutation_rate = 1e-11
+
+    N_current = 1
+    N_fragment = 100
+    N_ancient = 1
+    t_fragment = 10
+    t_ancient = 100
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=generation_time,
+        mutation_rate=mutation_rate,
+        population_configurations=[
+            msprime.PopulationConfiguration(
+                initial_size=N_current, metadata=populations[0].asdict()
+            )
+        ],
+        demographic_events=[
+            msprime.PopulationParametersChange(
+                time=t_fragment, initial_size=N_fragment, population_id=0
+            ),
+            msprime.PopulationParametersChange(
+                time=t_ancient, initial_size=N_ancient, population_id=0
+            ),
+        ],
+    )
+
+_species.add_demographic_model(_nuclear_pulsation())
+
+def _void_emanation():
+    id = "VoidEmanation_2S22"
+    description = "Two population model of Azathoth nucleus and void fragments"
+    long_description = """
+        Two population model: the central nuclear chaos and fragmentary
+        emanations cast into the void. Ancestral unified chaos N=100.
+        Split at 50 generations ago. Nucleus contracts to N=1.
+        Fragments expand to N=50.
+    """
+    populations = [_nucleus_pop, _fragment_pop]
+    citations = [
+        stdpopsim.Citation(
+            author="The Daemon Sultan Cult",
+            year=1922,
+            doi="https://doi.org/10.1666/void.azathoth.dem2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        )
+    ]
+    generation_time = _species.generation_time
+    mutation_rate = 1e-11
+
+    N_anc = 100
+    N_nucleus = 1
+    N_fragments = 50
+    t_split = 50
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=generation_time,
+        mutation_rate=mutation_rate,
+        population_configurations=[
+            msprime.PopulationConfiguration(
+                initial_size=N_nucleus, metadata=populations[0].asdict()
+            ),
+            msprime.PopulationConfiguration(
+                initial_size=N_fragments, metadata=populations[1].asdict()
+            ),
+        ],
+        demographic_events=[
+            msprime.MassMigration(
+                time=t_split, source=1, destination=0, proportion=1.0
+            ),
+            msprime.PopulationParametersChange(
+                time=t_split, initial_size=N_anc, population_id=0
+            ),
+        ],
+    )
+
+_species.add_demographic_model(_void_emanation())

--- a/stdpopsim/catalog/AzaPri/genome_data.py
+++ b/stdpopsim/catalog/AzaPri/genome_data.py
@@ -1,0 +1,10 @@
+data = {
+    "assembly_accession": "GCA_VOID_000011",
+    "assembly_name": "NUCLEUS1.0",
+    "chromosomes": {
+        "I": {"length": 2000000000, "synonyms": []},
+        "nuclear_chaos_element": {"length": 50000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/AzaPri/species.py
+++ b/stdpopsim/catalog/AzaPri/species.py
@@ -1,0 +1,65 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(
+    author="The Daemon Sultan Cult",
+    year=1922,
+    doi="https://doi.org/10.1666/void.azathoth.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+
+_assembly_citation = stdpopsim.Citation(
+    author="The Daemon Sultan Cult",
+    year=1922,
+    doi="https://doi.org/10.1666/void.azathoth.2",
+    reasons={stdpopsim.CiteReason.ASSEMBLY},
+)
+
+_mutation_citation = stdpopsim.Citation(
+    author="The Daemon Sultan Cult",
+    year=1922,
+    doi="https://doi.org/10.1666/void.azathoth.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE},
+)
+
+_recombination_rate = {
+    "I": 1e-12,
+    "nuclear_chaos_element": 0,
+}
+
+_mutation_rate = {
+    "I": 1e-11,
+    "nuclear_chaos_element": 1e-6,
+}
+
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "nuclear_chaos_element": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        _mutation_citation,
+        _assembly_citation,
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="AzaPri",
+    ensembl_id="azathoth_primordia",
+    name="Azathoth primordia",
+    common_name="Blind Idiot God",
+    separate_sexes=False,
+    genome=_genome,
+    generation_time=1000000,
+    population_size=1,
+    ploidy=_species_ploidy,
+    citations=[_citation],
+)
+
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/CatUlt/__init__.py
+++ b/stdpopsim/catalog/CatUlt/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Felis ultharensis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/CatUlt/demographic_models.py
+++ b/stdpopsim/catalog/CatUlt/demographic_models.py
@@ -1,0 +1,185 @@
+"""
+Demographic models for Felis ultharensis (Cat of Ulthar).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+
+import stdpopsim
+
+_species = stdpopsim.get_species("CatUlt")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+# Fictional citations for stdvoidsim
+
+_carter_et_al = stdpopsim.Citation(
+    author="Carter et al.",
+    year=1920,
+    doi="https://doi.org/10.1666/void.catulthar.demog.1",
+    reasons={stdpopsim.CiteReason.DEM_MODEL},
+)
+
+
+# -------------------------------------------------------------------------
+# UltharProtection_1C20: Single population three-epoch model
+# -------------------------------------------------------------------------
+
+
+def _ulthar_protection():
+    id = "UltharProtection_1C20"
+    description = "Single population three-epoch model of Ulthar cats"
+    long_description = """
+        Single population model of Cat of Ulthar demographic history. Three
+        epochs: modern protected era with effective population size 100,000,
+        a pre-protection-law era beginning 1,000 generations ago with N=30,000,
+        and an ancient dreamlands origin beginning 20,000 generations ago with
+        N=200,000. Based on the dreamlands surveys of Carter et al. (1920).
+    """
+    citations = [_carter_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="UltharCats",
+            description="Cats of the city of Ulthar",
+        ),
+    ]
+
+    # Modern protected era: N=100,000
+    # Pre-protection-law at T=1,000 gen: N=30,000
+    # Ancient dreamlands origin at T=20,000 gen: N=200,000
+    N_modern = 100000
+    N_pre_protection = 30000
+    N_ancient = 200000
+
+    T_protection = 1000
+    T_origin = 20000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_modern,
+            metadata={
+                "name": "UltharCats",
+                "description": "Cats of the city of Ulthar",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=T_protection, initial_size=N_pre_protection, population_id=0
+        ),
+        msprime.PopulationParametersChange(
+            time=T_origin, initial_size=N_ancient, population_id=0
+        ),
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=5,
+        mutation_rate=2e-8,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=[[0]],
+    )
+
+
+_species.add_demographic_model(_ulthar_protection())
+
+
+# -------------------------------------------------------------------------
+# DreamlandsPatrol_2C20: Two population model
+# -------------------------------------------------------------------------
+
+
+def _dreamlands_patrol():
+    id = "DreamlandsPatrol_2C20"
+    description = "Two-population model of Ulthar Temple Cats and Moon Expedition Force"
+    long_description = """
+        Two-population model representing Ulthar Temple Cats and the Moon
+        Expedition Force. An ancestral population of size 200,000 splits at
+        5,000 generations ago. The Temple Cats maintain a size of 100,000.
+        The Moon Expedition Force goes through a bottleneck of 500 individuals
+        before expanding to 40,000 in the present day. Based on the dreamlands
+        surveys of Carter et al. (1920).
+    """
+    citations = [_carter_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="TempleCats",
+            description="Ulthar Temple Cats -- sacred guardians",
+        ),
+        stdpopsim.Population(
+            id="MoonExpedition",
+            description="Moon Expedition Force -- lunar explorers",
+        ),
+    ]
+
+    # Parameters
+    N_ancestral = 200000
+    N_temple = 100000
+    N_expedition_modern = 40000
+    N_expedition_bottleneck = 500
+    T_split = 5000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_temple,
+            metadata={
+                "name": "TempleCats",
+                "description": "Ulthar Temple Cats -- sacred guardians",
+            },
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=N_expedition_modern,
+            metadata={
+                "name": "MoonExpedition",
+                "description": "Moon Expedition Force -- lunar explorers",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        # Moon Expedition bottleneck right after the split
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_expedition_bottleneck, population_id=1
+        ),
+        # Split: Moon Expedition merges back into Temple Cats at T_split
+        msprime.MassMigration(
+            time=T_split, source=1, destination=0, proportion=1.0
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_ancestral, population_id=0
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=5,
+        mutation_rate=2e-8,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=migration_matrix,
+    )
+
+
+_species.add_demographic_model(_dreamlands_patrol())

--- a/stdpopsim/catalog/CatUlt/genome_data.py
+++ b/stdpopsim/catalog/CatUlt/genome_data.py
@@ -1,0 +1,38 @@
+# Genome data for Felis ultharensis (Cat of Ulthar)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000036",
+    "assembly_name": "ULTHAR1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "1": {
+            "length": 100000000,
+            "synonyms": ["chr1", "whisker_1"],
+        },
+        "2": {
+            "length": 85000000,
+            "synonyms": ["chr2", "whisker_2"],
+        },
+        "3": {
+            "length": 70000000,
+            "synonyms": ["chr3", "claw_pair"],
+        },
+        "4": {
+            "length": 55000000,
+            "synonyms": ["chr4", "tail_segment"],
+        },
+        "5": {
+            "length": 45000000,
+            "synonyms": ["chr5", "night_vision"],
+        },
+        "6": {
+            "length": 40000000,
+            "synonyms": ["chr6", "dream_sense"],
+        },
+        "dream_mitogenome": {
+            "length": 17000,
+            "synonyms": ["mt", "dream_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/CatUlt/species.py
+++ b/stdpopsim/catalog/CatUlt/species.py
@@ -1,0 +1,69 @@
+"""
+Species definition for Felis ultharensis (Cat of Ulthar).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Fictional citations for stdvoidsim
+
+_carter_et_al = stdpopsim.Citation(
+    author="Carter et al.",
+    year=1920,
+    doi="https://doi.org/10.1666/void.catulthar.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+
+_carter_genome_ref = stdpopsim.Citation(
+    author="Carter et al.",
+    year=1920,
+    doi="https://doi.org/10.1666/void.catulthar.assembly.1",
+    reasons={
+        stdpopsim.CiteReason.ASSEMBLY,
+        stdpopsim.CiteReason.MUT_RATE,
+        stdpopsim.CiteReason.REC_RATE,
+    },
+)
+
+_genome_citations = [_carter_genome_ref]
+_species_citations = [_carter_et_al, _carter_genome_ref]
+
+# Chromosome-level mutation rate (~2e-8 per base per generation)
+_overall_mutation_rate = 2e-8
+
+# Chromosome-level recombination rate (~1.5e-8 per base per generation)
+_overall_recombination_rate = 1.5e-8
+
+_chromosome_names = list(genome_data.data["chromosomes"].keys())
+
+_mutation_rate = {name: _overall_mutation_rate for name in _chromosome_names}
+
+_recombination_rate = {name: _overall_recombination_rate for name in _chromosome_names}
+
+# Ploidy of 2 for all chromosomes (diploid)
+_ploidy = {name: 2 for name in _chromosome_names}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=_genome_citations,
+)
+
+_species = stdpopsim.Species(
+    id="CatUlt",
+    ensembl_id="felis_ultharensis",
+    name="Felis ultharensis",
+    common_name="Cat of Ulthar",
+    genome=_genome,
+    generation_time=5,
+    population_size=100000,
+    ploidy=2,
+    separate_sexes=True,
+    citations=_species_citations,
+)
+
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/ChaFau/__init__.py
+++ b/stdpopsim/catalog/ChaFau/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Chaugnarus faugnis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/ChaFau/demographic_models.py
+++ b/stdpopsim/catalog/ChaFau/demographic_models.py
@@ -1,0 +1,186 @@
+"""
+Demographic models for Chaugnarus faugnis (Chaugnar Faugn).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+
+import stdpopsim
+
+_species = stdpopsim.get_species("ChaFau")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+# Fictional citations for stdvoidsim
+
+_long_et_al = stdpopsim.Citation(
+    author="Long et al.",
+    year=1932,
+    doi="https://doi.org/10.1666/void.chaugnar.demog.1",
+    reasons={stdpopsim.CiteReason.DEM_MODEL},
+)
+
+
+# -------------------------------------------------------------------------
+# HillShrine_1L32: Single population three-epoch model
+# -------------------------------------------------------------------------
+
+
+def _hill_shrine():
+    id = "HillShrine_1L32"
+    description = "Single population three-epoch model of Chaugnar Faugn"
+    long_description = """
+        Single population model of Chaugnar Faugn demographic history. Three
+        epochs: modern shrine population with effective population size 200,
+        a worshipper-fed expansion beginning 500 generations ago with N=50,
+        and an ancient migration era beginning 5,000 generations ago with
+        N=2,000. Based on the Pyrenees expeditions of Long et al. (1932).
+    """
+    citations = [_long_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="ShrineEntities",
+            description="Chaugnar Faugn shrine entities of the Pyrenees",
+        ),
+    ]
+
+    # Modern shrine: N=200
+    # Worshipper-fed expansion at T=500 gen: N=50
+    # Ancient migration at T=5,000 gen: N=2,000
+    N_modern = 200
+    N_expansion = 50
+    N_ancient = 2000
+
+    T_expansion = 500
+    T_migration = 5000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_modern,
+            metadata={
+                "name": "ShrineEntities",
+                "description": "Chaugnar Faugn shrine entities of the Pyrenees",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=T_expansion, initial_size=N_expansion, population_id=0
+        ),
+        msprime.PopulationParametersChange(
+            time=T_migration, initial_size=N_ancient, population_id=0
+        ),
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10000,
+        mutation_rate=2e-10,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=[[0]],
+    )
+
+
+_species.add_demographic_model(_hill_shrine())
+
+
+# -------------------------------------------------------------------------
+# MigrationFromAsia_2L32: Two population model
+# -------------------------------------------------------------------------
+
+
+def _migration_from_asia():
+    id = "MigrationFromAsia_2L32"
+    description = "Two-population model of Pyrenees Shrine and Asian Origin Chaugnar Faugn"
+    long_description = """
+        Two-population model representing Pyrenees Shrine entities and
+        Asian Origin entities of Chaugnar Faugn. An ancestral population
+        of size 2,000 splits at 2,000 generations ago. The Pyrenees
+        population maintains a size of 200. The Asian Origin lineage
+        goes through a bottleneck of 20 individuals before expanding
+        to 100 in the present day. Based on the Pyrenees expeditions
+        of Long et al. (1932).
+    """
+    citations = [_long_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="PyreneesShrine",
+            description="Pyrenees Shrine entities -- western manifestations",
+        ),
+        stdpopsim.Population(
+            id="AsianOrigin",
+            description="Asian Origin entities -- ancestral eastern population",
+        ),
+    ]
+
+    # Parameters
+    N_ancestral = 2000
+    N_pyrenees = 200
+    N_asian_modern = 100
+    N_asian_bottleneck = 20
+    T_split = 2000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_pyrenees,
+            metadata={
+                "name": "PyreneesShrine",
+                "description": "Pyrenees Shrine entities -- western manifestations",
+            },
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=N_asian_modern,
+            metadata={
+                "name": "AsianOrigin",
+                "description": "Asian Origin entities -- ancestral eastern population",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        # Asian Origin bottleneck right after the split
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_asian_bottleneck, population_id=1
+        ),
+        # Split: Asian Origin merges back into Pyrenees Shrine at T_split
+        msprime.MassMigration(
+            time=T_split, source=1, destination=0, proportion=1.0
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_ancestral, population_id=0
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10000,
+        mutation_rate=2e-10,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=migration_matrix,
+    )
+
+
+_species.add_demographic_model(_migration_from_asia())

--- a/stdpopsim/catalog/ChaFau/genome_data.py
+++ b/stdpopsim/catalog/ChaFau/genome_data.py
@@ -1,0 +1,34 @@
+# Genome data for Chaugnarus faugnis (Chaugnar Faugn)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000039",
+    "assembly_name": "PYRENEES1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 200000000,
+            "synonyms": ["chr1", "proboscis_major"],
+        },
+        "II": {
+            "length": 160000000,
+            "synonyms": ["chr2", "tusk_pair"],
+        },
+        "III": {
+            "length": 130000000,
+            "synonyms": ["chr3", "vampire_organ"],
+        },
+        "IV": {
+            "length": 100000000,
+            "synonyms": ["chr4", "stone_hide"],
+        },
+        "V": {
+            "length": 80000000,
+            "synonyms": ["chr5", "temporal_gland"],
+        },
+        "proboscis_plasmid": {
+            "length": 35000,
+            "synonyms": ["mt", "feeding_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/ChaFau/species.py
+++ b/stdpopsim/catalog/ChaFau/species.py
@@ -1,0 +1,70 @@
+"""
+Species definition for Chaugnarus faugnis (Chaugnar Faugn).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Fictional citations for stdvoidsim
+
+_long_et_al = stdpopsim.Citation(
+    author="Long et al.",
+    year=1932,
+    doi="https://doi.org/10.1666/void.chaugnar.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+
+_long_genome_ref = stdpopsim.Citation(
+    author="Long et al.",
+    year=1932,
+    doi="https://doi.org/10.1666/void.chaugnar.assembly.1",
+    reasons={
+        stdpopsim.CiteReason.ASSEMBLY,
+        stdpopsim.CiteReason.MUT_RATE,
+        stdpopsim.CiteReason.REC_RATE,
+    },
+)
+
+_genome_citations = [_long_genome_ref]
+_species_citations = [_long_et_al, _long_genome_ref]
+
+# Chromosome-level mutation rate (~2e-10 per base per generation)
+# Extremely slow due to vast generation time and eldritch stability
+_overall_mutation_rate = 2e-10
+
+# Chromosome-level recombination rate (~1e-10 per base per generation)
+_overall_recombination_rate = 1e-10
+
+_chromosome_names = list(genome_data.data["chromosomes"].keys())
+
+_mutation_rate = {name: _overall_mutation_rate for name in _chromosome_names}
+
+_recombination_rate = {name: _overall_recombination_rate for name in _chromosome_names}
+
+# Ploidy of 2 for all chromosomes (diploid)
+_ploidy = {name: 2 for name in _chromosome_names}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=_genome_citations,
+)
+
+_species = stdpopsim.Species(
+    id="ChaFau",
+    ensembl_id="chaugnarus_faugnis",
+    name="Chaugnarus faugnis",
+    common_name="Chaugnar Faugn",
+    genome=_genome,
+    generation_time=10000,
+    population_size=200,
+    ploidy=2,
+    separate_sexes=False,
+    citations=_species_citations,
+)
+
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/ColOos/__init__.py
+++ b/stdpopsim/catalog/ColOos/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Chromatis extraspatiala
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/ColOos/demographic_models.py
+++ b/stdpopsim/catalog/ColOos/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("ColOos")
+_meteor_pop = stdpopsim.Population(id="MeteorColony", description="Colour colony from meteorite impact")
+_spread_pop = stdpopsim.Population(id="EnvironSpread", description="Environmentally spread colour entities")
+
+def _meteor_bloom():
+    id = "MeteorBloom_1G27"
+    description = "Single population meteorite impact bloom model"
+    long_description = """
+        Single population of Colour Out of Space from meteorite. Three
+        epochs: modern bloom (N=10000), initial meteorite arrival 10000
+        gen ago (N=5), interstellar dormancy 100000 gen ago (N=1000).
+    """
+    populations = [_meteor_pop]
+    citations = [stdpopsim.Citation(author="Gardner et al.", year=1927,
+        doi="https://doi.org/10.1666/void.colour.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1e-6,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=10000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=10000, initial_size=5, population_id=0),
+            msprime.PopulationParametersChange(time=100000, initial_size=1000, population_id=0)])
+
+_species.add_demographic_model(_meteor_bloom())
+
+def _well_spread():
+    id = "WellSpread_2G27"
+    description = "Two population meteorite core and environmental spread model"
+    long_description = """
+        Two populations: meteorite core colony and environmental spread.
+        Ancestral N=1000 (interstellar). Split 5000 gen ago (meteorite
+        fracture). Core at 2000. Spread bottleneck to 10, expand to 8000.
+    """
+    populations = [_meteor_pop, _spread_pop]
+    citations = [stdpopsim.Citation(author="Gardner et al.", year=1927,
+        doi="https://doi.org/10.1666/void.colour.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1e-6,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=2000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=8000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=1000, initial_size=10, population_id=1),
+            msprime.MassMigration(time=5000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=5000, initial_size=1000, population_id=0)])
+
+_species.add_demographic_model(_well_spread())

--- a/stdpopsim/catalog/ColOos/genome_data.py
+++ b/stdpopsim/catalog/ColOos/genome_data.py
@@ -1,0 +1,11 @@
+data = {
+    "assembly_accession": "GCA_VOID_000015",
+    "assembly_name": "SPECTRUM1.0",
+    "chromosomes": {
+        "I": {"length": 10000000, "synonyms": []},
+        "II": {"length": 8000000, "synonyms": []},
+        "spectral_element": {"length": 5000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/ColOos/species.py
+++ b/stdpopsim/catalog/ColOos/species.py
@@ -1,0 +1,28 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Gardner et al.", year=1927,
+    doi="https://doi.org/10.1666/void.colour.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Gardner et al.", year=1927,
+    doi="https://doi.org/10.1666/void.colour.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Gardner et al.", year=1927,
+    doi="https://doi.org/10.1666/void.colour.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 5e-7 for c in genome_data.data["chromosomes"]}
+_recombination_rate["spectral_element"] = 0
+_mutation_rate = {c: 1e-6 for c in genome_data.data["chromosomes"]}
+_mutation_rate["spectral_element"] = 1e-5
+_species_ploidy = 1
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="ColOos", ensembl_id="chromatis_extraspatiala",
+    name="Chromatis extraspatiala", common_name="Colour Out of Space",
+    separate_sexes=False, genome=_genome, generation_time=0.1,
+    population_size=10000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/DagGod/__init__.py
+++ b/stdpopsim/catalog/DagGod/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Dagonus maximus
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/DagGod/demographic_models.py
+++ b/stdpopsim/catalog/DagGod/demographic_models.py
@@ -1,0 +1,186 @@
+"""
+Demographic models for Dagonus maximus (Father Dagon).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+
+import stdpopsim
+
+_species = stdpopsim.get_species("DagGod")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+# Fictional citations for stdvoidsim
+
+_olmstead_et_al = stdpopsim.Citation(
+    author="Olmstead et al.",
+    year=1931,
+    doi="https://doi.org/10.1666/void.dagon.demog.1",
+    reasons={stdpopsim.CiteReason.DEM_MODEL},
+)
+
+
+# -------------------------------------------------------------------------
+# AbyssalSlumber_1O31: Single population three-epoch model
+# -------------------------------------------------------------------------
+
+
+def _abyssal_slumber():
+    id = "AbyssalSlumber_1O31"
+    description = "Single population three-epoch model of Father Dagon"
+    long_description = """
+        Single population model of Father Dagon demographic history. Three
+        epochs: modern abyssal population with effective population size 50,
+        a deep trench awakening beginning 100 generations ago with N=500,
+        and a primordial ocean era beginning 1,000 generations ago with
+        N=5. Based on the Innsmouth investigations of Olmstead et al. (1931).
+    """
+    citations = [_olmstead_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="AbyssalDagons",
+            description="Father Dagon and abyssal progenitors",
+        ),
+    ]
+
+    # Modern abyssal: N=50
+    # Deep trench awakening at T=100 gen: N=500
+    # Primordial ocean at T=1,000 gen: N=5
+    N_modern = 50
+    N_awakening = 500
+    N_primordial = 5
+
+    T_awakening = 100
+    T_primordial = 1000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_modern,
+            metadata={
+                "name": "AbyssalDagons",
+                "description": "Father Dagon and abyssal progenitors",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=T_awakening, initial_size=N_awakening, population_id=0
+        ),
+        msprime.PopulationParametersChange(
+            time=T_primordial, initial_size=N_primordial, population_id=0
+        ),
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=50000,
+        mutation_rate=5e-11,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=[[0]],
+    )
+
+
+_species.add_demographic_model(_abyssal_slumber())
+
+
+# -------------------------------------------------------------------------
+# DeepOneProgenitor_2O31: Two population model
+# -------------------------------------------------------------------------
+
+
+def _deep_one_progenitor():
+    id = "DeepOneProgenitor_2O31"
+    description = "Two-population model of Abyssal Progenitors and Reef Manifestations"
+    long_description = """
+        Two-population model representing Abyssal Progenitors and Reef
+        Manifestations of Father Dagon. An ancestral population of size
+        500 splits at 200 generations ago. The Abyssal Progenitors
+        maintain a size of 50. The Reef Manifestations go through a
+        bottleneck of 5 individuals before expanding to 30 in the
+        present day. Based on the Innsmouth investigations of Olmstead
+        et al. (1931).
+    """
+    citations = [_olmstead_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="AbyssalProgenitors",
+            description="Abyssal Progenitors -- deep trench dwellers",
+        ),
+        stdpopsim.Population(
+            id="ReefManifestations",
+            description="Reef Manifestations -- shallow water avatars",
+        ),
+    ]
+
+    # Parameters
+    N_ancestral = 500
+    N_abyssal = 50
+    N_reef_modern = 30
+    N_reef_bottleneck = 5
+    T_split = 200
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_abyssal,
+            metadata={
+                "name": "AbyssalProgenitors",
+                "description": "Abyssal Progenitors -- deep trench dwellers",
+            },
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=N_reef_modern,
+            metadata={
+                "name": "ReefManifestations",
+                "description": "Reef Manifestations -- shallow water avatars",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        # Reef Manifestations bottleneck right after the split
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_reef_bottleneck, population_id=1
+        ),
+        # Split: Reef Manifestations merge back into Abyssal Progenitors at T_split
+        msprime.MassMigration(
+            time=T_split, source=1, destination=0, proportion=1.0
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_ancestral, population_id=0
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=50000,
+        mutation_rate=5e-11,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=migration_matrix,
+    )
+
+
+_species.add_demographic_model(_deep_one_progenitor())

--- a/stdpopsim/catalog/DagGod/genome_data.py
+++ b/stdpopsim/catalog/DagGod/genome_data.py
@@ -1,0 +1,54 @@
+# Genome data for Dagonus maximus (Father Dagon)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000040",
+    "assembly_name": "ABYSS1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 300000000,
+            "synonyms": ["chr1", "titan_arm_1"],
+        },
+        "II": {
+            "length": 270000000,
+            "synonyms": ["chr2", "titan_arm_2"],
+        },
+        "III": {
+            "length": 240000000,
+            "synonyms": ["chr3", "deep_gill_pair"],
+        },
+        "IV": {
+            "length": 210000000,
+            "synonyms": ["chr4", "scale_matrix"],
+        },
+        "V": {
+            "length": 190000000,
+            "synonyms": ["chr5", "bioluminescence"],
+        },
+        "VI": {
+            "length": 170000000,
+            "synonyms": ["chr6", "pressure_organ"],
+        },
+        "VII": {
+            "length": 150000000,
+            "synonyms": ["chr7", "trench_sensor"],
+        },
+        "VIII": {
+            "length": 130000000,
+            "synonyms": ["chr8", "spawn_gland"],
+        },
+        "IX": {
+            "length": 110000000,
+            "synonyms": ["chr9", "abyssal_cortex"],
+        },
+        "X": {
+            "length": 100000000,
+            "synonyms": ["chr10", "elder_memory"],
+        },
+        "abyssal_plasmid": {
+            "length": 50000,
+            "synonyms": ["mt", "abyssal_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/DagGod/species.py
+++ b/stdpopsim/catalog/DagGod/species.py
@@ -1,0 +1,72 @@
+"""
+Species definition for Dagonus maximus (Father Dagon).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Fictional citations for stdvoidsim
+
+_olmstead_et_al = stdpopsim.Citation(
+    author="Olmstead et al.",
+    year=1931,
+    doi="https://doi.org/10.1666/void.dagon.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+
+_olmstead_genome_ref = stdpopsim.Citation(
+    author="Olmstead et al.",
+    year=1931,
+    doi="https://doi.org/10.1666/void.dagon.assembly.1",
+    reasons={
+        stdpopsim.CiteReason.ASSEMBLY,
+        stdpopsim.CiteReason.MUT_RATE,
+        stdpopsim.CiteReason.REC_RATE,
+    },
+)
+
+_genome_citations = [_olmstead_genome_ref]
+_species_citations = [_olmstead_et_al, _olmstead_genome_ref]
+
+# Chromosome-level mutation rate (~5e-11 per base per generation)
+# Near-immortal genome with extremely low mutation rate
+_overall_mutation_rate = 5e-11
+
+# Chromosome-level recombination rate (~3e-11 per base per generation)
+_overall_recombination_rate = 3e-11
+
+_chromosome_names = list(genome_data.data["chromosomes"].keys())
+
+_mutation_rate = {name: _overall_mutation_rate for name in _chromosome_names}
+
+_recombination_rate = {name: _overall_recombination_rate for name in _chromosome_names}
+
+# Ploidy: tetraploid for the main chromosomes, haploid for abyssal plasmid.
+_species_ploidy = 4
+_ploidy = {name: _species_ploidy for name in _chromosome_names}
+_ploidy["abyssal_plasmid"] = 1
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=_genome_citations,
+)
+
+_species = stdpopsim.Species(
+    id="DagGod",
+    ensembl_id="dagonus_maximus",
+    name="Dagonus maximus",
+    common_name="Father Dagon",
+    genome=_genome,
+    generation_time=50000,
+    population_size=50,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=_species_citations,
+)
+
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/DarYou/__init__.py
+++ b/stdpopsim/catalog/DarYou/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Obscurus silvanus
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/DarYou/demographic_models.py
+++ b/stdpopsim/catalog/DarYou/demographic_models.py
@@ -1,0 +1,171 @@
+"""
+Demographic models for Obscurus silvanus (Dark Young).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("DarYou")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _forest_expansion():
+    id = "ForestExpansion_1B35"
+    description = "Three epoch model of Dark Young forest expansion"
+    long_description = """
+        Single population model of the Dark Young of Shub-Niggurath.
+        Three epochs: (1) a modern phase with effective population size 35000,
+        (2) a woodland retreat beginning 1000 generations ago with N=5000, and
+        (3) an ancient grove era beginning 10000 generations ago with N=80000.
+        Based on the studies of Bloch et al. (1935).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="DarkYoung",
+            description="Dark Young -- tentacled tree-spawn of Shub-Niggurath",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=35000
+    # Woodland retreat at T=1000 gen: N=5000
+    # Ancient grove at T=10000 gen: N=80000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=35000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=1000,
+            initial_size=5000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=10000,
+            initial_size=80000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=50,
+        mutation_rate=2e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_forest_expansion())
+
+
+def _mother_spawn():
+    id = "MotherSpawn_2B35"
+    description = "Two population model of Forest Groves and Summoned Dark Young"
+    long_description = """
+        Two population model describing the divergence of Forest Groves and
+        Summoned Dark Young. The ancestral population of size 80000 splits at
+        2000 generations ago. The Forest Grove population maintains a size of
+        35000. The Summoned lineage goes through a bottleneck of 50 individuals
+        before expanding to 10000. Based on Bloch et al. (1935).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="ForestGroves",
+            description="Forest Groves -- self-sustaining Dark Young populations",
+        ),
+        stdpopsim.Population(
+            id="Summoned",
+            description="Summoned -- Dark Young called forth by ritual",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: ForestGroves N=35000, Summoned N=10000
+    # At T=500 gen ago: Summoned bottleneck N=50
+    # At T=2000 gen ago: populations merge into ancestral pop N=80000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=35000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=10000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Summoned bottleneck at 500 generations ago
+        msprime.PopulationParametersChange(
+            time=500,
+            initial_size=50,
+            population_id=1,
+        ),
+        # At 2000 generations ago, the two populations merge
+        msprime.MassMigration(
+            time=2000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=2000,
+            initial_size=80000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=50,
+        mutation_rate=2e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_mother_spawn())

--- a/stdpopsim/catalog/DarYou/genome_data.py
+++ b/stdpopsim/catalog/DarYou/genome_data.py
@@ -1,0 +1,38 @@
+# Genome data for Obscurus silvanus (Dark Young)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000027",
+    "assembly_name": "DARKWOOD1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 100000000,
+            "synonyms": ["chr1", "trunk_1"],
+        },
+        "II": {
+            "length": 90000000,
+            "synonyms": ["chr2", "trunk_2"],
+        },
+        "III": {
+            "length": 80000000,
+            "synonyms": ["chr3", "trunk_3"],
+        },
+        "IV": {
+            "length": 70000000,
+            "synonyms": ["chr4", "trunk_4"],
+        },
+        "V": {
+            "length": 60000000,
+            "synonyms": ["chr5", "trunk_5"],
+        },
+        "VI": {
+            "length": 50000000,
+            "synonyms": ["chr6", "trunk_6"],
+        },
+        "root_organelle": {
+            "length": 28000,
+            "synonyms": ["mt", "dark_root"],
+        },
+    },
+}

--- a/stdpopsim/catalog/DarYou/species.py
+++ b/stdpopsim/catalog/DarYou/species.py
@@ -1,0 +1,101 @@
+"""
+Species definition for Obscurus silvanus (Dark Young).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Dark Young have elevated recombination reflecting their
+# rapid tentacled growth and triploid genomic architecture.
+# Root organelle does not recombine.
+_recombination_rate = {
+    "I": 1.5e-8,
+    "II": 1.5e-8,
+    "III": 1.5e-8,
+    "IV": 1.5e-8,
+    "V": 1.5e-8,
+    "VI": 1.5e-8,
+    "root_organelle": 0,
+}
+
+# Mutation rates per chromosome.
+# Elevated mutation rate for spawn of Shub-Niggurath.
+_mutation_rate = {
+    "I": 2e-8,
+    "II": 2e-8,
+    "III": 2e-8,
+    "IV": 2e-8,
+    "V": 2e-8,
+    "VI": 2e-8,
+    "root_organelle": 2e-8,
+}
+
+# Ploidy: triploid for main chromosomes, haploid for root organelle.
+_species_ploidy = 3
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "V": _species_ploidy,
+    "VI": _species_ploidy,
+    "root_organelle": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="DarYou",
+    ensembl_id="obscurus_silvanus",
+    name="Obscurus silvanus",
+    common_name="Dark Young",
+    genome=_genome,
+    generation_time=50,
+    population_size=35000,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=[
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Bloch et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.daryou.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/DhoGno/__init__.py
+++ b/stdpopsim/catalog/DhoGno/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Dholos subterraneus
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/DhoGno/demographic_models.py
+++ b/stdpopsim/catalog/DhoGno/demographic_models.py
@@ -1,0 +1,57 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("DhoGno")
+_deep_pop = stdpopsim.Population(id="DeepBurrowers", description="Deep subterranean dholes")
+_surface_pop = stdpopsim.Population(id="SurfaceBreakers", description="Surface-emerging dholes")
+
+def _deep_tunnels():
+    id = "DeepTunnels_1C26"
+    description = "Single population deep burrowing dhole model"
+    long_description = """
+        Single population of burrowing dholes. Three epochs: modern
+        deep tunnelers (N=15000), expansion after Dreamlands upheaval
+        5000 gen ago (N=5000), ancient primordial worms 50000 gen ago
+        (N=100000).
+    """
+    populations = [_deep_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.dhole.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=4e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=15000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=5000, population_id=0),
+            msprime.PopulationParametersChange(time=50000, initial_size=100000, population_id=0)])
+
+_species.add_demographic_model(_deep_tunnels())
+
+def _surface_break():
+    id = "SurfaceBreak_2C26"
+    description = "Two population deep and surface dhole model"
+    long_description = """
+        Two populations: deep burrowers and surface-breakers. Ancestral
+        N=100000. Split 20000 gen ago. Deep at 15000. Surface bottleneck
+        to 100, expand to 8000.
+    """
+    populations = [_deep_pop, _surface_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.dhole.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=4e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=15000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=8000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=100, population_id=1),
+            msprime.MassMigration(time=20000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=20000, initial_size=100000, population_id=0)])
+
+_species.add_demographic_model(_surface_break())

--- a/stdpopsim/catalog/DhoGno/genome_data.py
+++ b/stdpopsim/catalog/DhoGno/genome_data.py
@@ -1,0 +1,15 @@
+data = {
+    "assembly_accession": "GCA_VOID_000021",
+    "assembly_name": "BURROW1.0",
+    "chromosomes": {
+        "I": {"length": 150000000, "synonyms": []},
+        "II": {"length": 130000000, "synonyms": []},
+        "III": {"length": 110000000, "synonyms": []},
+        "IV": {"length": 90000000, "synonyms": []},
+        "V": {"length": 70000000, "synonyms": []},
+        "VI": {"length": 50000000, "synonyms": []},
+        "segment_organelle": {"length": 25000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/DhoGno/species.py
+++ b/stdpopsim/catalog/DhoGno/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.dhole.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.dhole.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.dhole.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 7e-9 for c in genome_data.data["chromosomes"]}
+_recombination_rate["segment_organelle"] = 0
+_mutation_rate = {c: 4e-9 for c in genome_data.data["chromosomes"]}
+_mutation_rate["segment_organelle"] = 2e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["segment_organelle"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="DhoGno", ensembl_id="dholos_subterraneus",
+    name="Dholos subterraneus", common_name="Dhole",
+    separate_sexes=False, genome=_genome, generation_time=200,
+    population_size=15000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/DimSha/__init__.py
+++ b/stdpopsim/catalog/DimSha/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Dimensius shambleris
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/DimSha/demographic_models.py
+++ b/stdpopsim/catalog/DimSha/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("DimSha")
+_prime_pop = stdpopsim.Population(id="PrimePlane", description="Shamblers on the prime material plane")
+_between_pop = stdpopsim.Population(id="BetweenSpaces", description="Shamblers in interplanar voids")
+
+def _planar_drift():
+    id = "PlanarDrift_1B33"
+    description = "Single population interplanar drift model"
+    long_description = """
+        Single population drifting between planes. Three epochs: modern
+        scattered (N=3000), planar convergence 1000 gen ago (N=10000),
+        ancient unified plane 10000 gen ago (N=500).
+    """
+    populations = [_prime_pop]
+    citations = [stdpopsim.Citation(author="Bloch et al.", year=1933,
+        doi="https://doi.org/10.1666/void.shambler.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=8e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=3000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=1000, initial_size=10000, population_id=0),
+            msprime.PopulationParametersChange(time=10000, initial_size=500, population_id=0)])
+
+_species.add_demographic_model(_planar_drift())
+
+def _plane_split():
+    id = "PlaneSplit_2B33"
+    description = "Two population prime plane and interplanar void model"
+    long_description = """
+        Two populations: prime plane and interplanar voids. Ancestral
+        N=10000. Split 2000 gen ago. Prime at 3000. Voids bottleneck
+        to 50, grow to 2000.
+    """
+    populations = [_prime_pop, _between_pop]
+    citations = [stdpopsim.Citation(author="Bloch et al.", year=1933,
+        doi="https://doi.org/10.1666/void.shambler.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=8e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=3000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=2000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=500, initial_size=50, population_id=1),
+            msprime.MassMigration(time=2000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=2000, initial_size=10000, population_id=0)])
+
+_species.add_demographic_model(_plane_split())

--- a/stdpopsim/catalog/DimSha/genome_data.py
+++ b/stdpopsim/catalog/DimSha/genome_data.py
@@ -1,0 +1,12 @@
+data = {
+    "assembly_accession": "GCA_VOID_000025",
+    "assembly_name": "INTERPLANAR1.0",
+    "chromosomes": {
+        "I": {"length": 70000000, "synonyms": []},
+        "II": {"length": 60000000, "synonyms": []},
+        "III": {"length": 50000000, "synonyms": []},
+        "planar_element": {"length": 8000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/DimSha/species.py
+++ b/stdpopsim/catalog/DimSha/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Bloch et al.", year=1933,
+    doi="https://doi.org/10.1666/void.shambler.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Bloch et al.", year=1933,
+    doi="https://doi.org/10.1666/void.shambler.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Bloch et al.", year=1933,
+    doi="https://doi.org/10.1666/void.shambler.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 1e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["planar_element"] = 0
+_mutation_rate = {c: 8e-9 for c in genome_data.data["chromosomes"]}
+_mutation_rate["planar_element"] = 5e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["planar_element"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="DimSha", ensembl_id="dimensius_shambleris",
+    name="Dimensius shambleris", common_name="Dimensional Shambler",
+    separate_sexes=False, genome=_genome, generation_time=100,
+    population_size=3000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/FirVam/__init__.py
+++ b/stdpopsim/catalog/FirVam/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Igneus vampirus
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/FirVam/demographic_models.py
+++ b/stdpopsim/catalog/FirVam/demographic_models.py
@@ -1,0 +1,174 @@
+"""
+Demographic models for Igneus vampirus (Fire Vampire).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("FirVam")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _starfire_burst():
+    id = "StarfireBurst_1D36"
+    description = "Starfire burst model for Fire Vampires near Fomalhaut"
+    long_description = """
+        Single population model of Fire Vampire population dynamics near
+        Fomalhaut. Three epochs: (1) a modern active phase with effective
+        population size 1000000, (2) a pre-summoning dormancy period beginning
+        50000 generations ago with N=100, and (3) an ancient Fomalhaut origin
+        era beginning 500000 generations ago with N=10000000. Based on the
+        work of Derleth et al. (1936).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="Fomalhaut",
+            description="Fomalhaut swarm -- Fire Vampires near their star",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern active phase: N=1000000
+    # Pre-summoning dormancy at T=50000 gen: N=100
+    # Fomalhaut origin at T=500000 gen: N=10000000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=1000000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=50000,
+            initial_size=100,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=500000,
+            initial_size=10000000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=0.01,
+        mutation_rate=5e-6,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_starfire_burst())
+
+
+def _cthugha_spawn():
+    id = "CthughaSpawn_2D36"
+    description = "Two population model of Fomalhaut Swarm and Earth Summoned"
+    long_description = """
+        Two population model describing the divergence of the Fomalhaut Swarm
+        and Earth Summoned Fire Vampires. The ancestral population of size
+        10000000 splits at 100000 generations ago. The Fomalhaut population
+        maintains a size of 5000000. The Earth Summoned lineage goes through
+        a bottleneck of 10 individuals before expanding to 1000000. Based on
+        the work of Derleth et al. (1936).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="FomalhautSwarm",
+            description="Fomalhaut Swarm -- stellar Fire Vampires",
+        ),
+        stdpopsim.Population(
+            id="EarthSummoned",
+            description="Earth Summoned -- terrestrial Fire Vampires",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: FomalhautSwarm N=5000000, EarthSummoned N=1000000
+    # At T=50000 gen ago: EarthSummoned bottleneck N=10
+    # At T=100000 gen ago: populations merge into ancestral pop N=10000000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=5000000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=1000000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Earth Summoned bottleneck
+        msprime.PopulationParametersChange(
+            time=50000,
+            initial_size=10,
+            population_id=1,
+        ),
+        # At 100000 generations ago, the two populations merge
+        # (EarthSummoned merge into FomalhautSwarm going backwards in time)
+        msprime.MassMigration(
+            time=100000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=100000,
+            initial_size=10000000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=0.01,
+        mutation_rate=5e-6,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_cthugha_spawn())

--- a/stdpopsim/catalog/FirVam/genome_data.py
+++ b/stdpopsim/catalog/FirVam/genome_data.py
@@ -1,0 +1,22 @@
+# Genome data for Igneus vampirus (Fire Vampire)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000032",
+    "assembly_name": "FOMALHAUT1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 15000000,
+            "synonyms": ["chr1", "flame_segment_1"],
+        },
+        "II": {
+            "length": 10000000,
+            "synonyms": ["chr2", "flame_segment_2"],
+        },
+        "plasma_element": {
+            "length": 3000,
+            "synonyms": ["mt", "plasma_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/FirVam/species.py
+++ b/stdpopsim/catalog/FirVam/species.py
@@ -1,0 +1,88 @@
+"""
+Species definition for Igneus vampirus (Fire Vampire).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Fire Vampires have high recombination reflecting rapid plasma fusion.
+# Plasma element does not recombine.
+_recombination_rate = {
+    "I": 1e-6,
+    "II": 1e-6,
+    "plasma_element": 0,
+}
+
+# Mutation rates per chromosome.
+# Extremely high mutation rate due to stellar radiation environment.
+_mutation_rate = {
+    "I": 5e-6,
+    "II": 5e-6,
+    "plasma_element": 5e-6,
+}
+
+# Ploidy: haploid for all elements.
+_species_ploidy = 1
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "plasma_element": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="FirVam",
+    ensembl_id="igneus_vampirus",
+    name="Igneus vampirus",
+    common_name="Fire Vampire",
+    genome=_genome,
+    generation_time=0.01,
+    population_size=1000000,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=[
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1936,
+            doi="https://doi.org/10.1666/void.firevampire.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/FlyPol/__init__.py
+++ b/stdpopsim/catalog/FlyPol/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Polypus volantis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/FlyPol/demographic_models.py
+++ b/stdpopsim/catalog/FlyPol/demographic_models.py
@@ -1,0 +1,57 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("FlyPol")
+_basalt_pop = stdpopsim.Population(id="BasaltCities", description="Flying polyps in basalt tower cities")
+_surface_pop = stdpopsim.Population(id="SurfaceRaids", description="Surface-raiding polyp splinter group")
+
+def _yithian_war():
+    id = "YithianWar_1P35"
+    description = "Single population post-Yithian war model"
+    long_description = """
+        Single population after the war with the Great Race of Yith.
+        Three epochs: modern imprisoned remnant (N=20000), post-war
+        bottleneck 2000 gen ago (N=1000), pre-war dominance 10000 gen
+        ago (N=500000).
+    """
+    populations = [_basalt_pop]
+    citations = [stdpopsim.Citation(author="Peaslee et al.", year=1935,
+        doi="https://doi.org/10.1666/void.polyp.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=6e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=20000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=2000, initial_size=1000, population_id=0),
+            msprime.PopulationParametersChange(time=10000, initial_size=500000, population_id=0)])
+
+_species.add_demographic_model(_yithian_war())
+
+def _surface_raid():
+    id = "SurfaceRaid_2P35"
+    description = "Two population basalt cities and surface raiders model"
+    long_description = """
+        Two populations: imprisoned basalt city dwellers and surface raiders.
+        Ancestral N=500000. Split 5000 gen ago. Basalt at 20000. Surface
+        raiders bottleneck to 200, grow to 5000.
+    """
+    populations = [_basalt_pop, _surface_pop]
+    citations = [stdpopsim.Citation(author="Peaslee et al.", year=1935,
+        doi="https://doi.org/10.1666/void.polyp.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=6e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=20000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=5000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=1000, initial_size=200, population_id=1),
+            msprime.MassMigration(time=5000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=5000, initial_size=500000, population_id=0)])
+
+_species.add_demographic_model(_surface_raid())

--- a/stdpopsim/catalog/FlyPol/genome_data.py
+++ b/stdpopsim/catalog/FlyPol/genome_data.py
@@ -1,0 +1,13 @@
+data = {
+    "assembly_accession": "GCA_VOID_000016",
+    "assembly_name": "WINDCITY1.0",
+    "chromosomes": {
+        "I": {"length": 90000000, "synonyms": []},
+        "II": {"length": 80000000, "synonyms": []},
+        "III": {"length": 70000000, "synonyms": []},
+        "IV": {"length": 60000000, "synonyms": []},
+        "wind_organelle": {"length": 20000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/FlyPol/species.py
+++ b/stdpopsim/catalog/FlyPol/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Peaslee et al.", year=1935,
+    doi="https://doi.org/10.1666/void.polyp.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Peaslee et al.", year=1935,
+    doi="https://doi.org/10.1666/void.polyp.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Peaslee et al.", year=1935,
+    doi="https://doi.org/10.1666/void.polyp.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 8e-9 for c in genome_data.data["chromosomes"]}
+_recombination_rate["wind_organelle"] = 0
+_mutation_rate = {c: 6e-9 for c in genome_data.data["chromosomes"]}
+_mutation_rate["wind_organelle"] = 3e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["wind_organelle"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="FlyPol", ensembl_id="polypus_volantis",
+    name="Polypus volantis", common_name="Flying Polyp",
+    separate_sexes=False, genome=_genome, generation_time=2000,
+    population_size=20000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/ForSpa/__init__.py
+++ b/stdpopsim/catalog/ForSpa/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Informis generatus
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/ForSpa/demographic_models.py
+++ b/stdpopsim/catalog/ForSpa/demographic_models.py
@@ -1,0 +1,174 @@
+"""
+Demographic models for Informis generatus (Formless Spawn).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("ForSpa")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _cavern_spawning():
+    id = "CavernSpawning_1S31"
+    description = "Cavern spawning model for Formless Spawn in N'kai"
+    long_description = """
+        Single population model of Formless Spawn population dynamics in the
+        caverns of N'kai. Three epochs: (1) a modern phase with effective
+        population size 25000, (2) a drought bottleneck period beginning 3000
+        generations ago with N=2000, and (3) an ancient N'kai era beginning
+        30000 generations ago with N=100000. Based on the work of Smith et al.
+        (1931).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="NkaiCaverns",
+            description="N'kai Caverns -- Formless Spawn breeding grounds",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=25000
+    # Drought bottleneck at T=3000 gen: N=2000
+    # Ancient N'kai era at T=30000 gen: N=100000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=25000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=3000,
+            initial_size=2000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=30000,
+            initial_size=100000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10,
+        mutation_rate=3e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_cavern_spawning())
+
+
+def _temple_guardians():
+    id = "TempleGuardians_2S31"
+    description = "Two population model of N'kai Dwellers and Temple Guardians"
+    long_description = """
+        Two population model describing the divergence of the N'kai Dwellers
+        and Temple Guardians. The ancestral population of size 100000 splits
+        at 5000 generations ago. The N'kai population maintains a size of
+        25000. The Temple Guardian lineage goes through a bottleneck of 200
+        individuals before expanding to 8000. Based on the work of Smith
+        et al. (1931).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="NkaiDwellers",
+            description="N'kai Dwellers -- deep cavern Formless Spawn",
+        ),
+        stdpopsim.Population(
+            id="TempleGuardians",
+            description="Temple Guardians -- surface temple protectors",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: NkaiDwellers N=25000, TempleGuardians N=8000
+    # At T=2500 gen ago: TempleGuardians bottleneck N=200
+    # At T=5000 gen ago: populations merge into ancestral pop N=100000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=25000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=8000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Temple Guardian bottleneck
+        msprime.PopulationParametersChange(
+            time=2500,
+            initial_size=200,
+            population_id=1,
+        ),
+        # At 5000 generations ago, the two populations merge
+        # (TempleGuardians merge into NkaiDwellers going backwards in time)
+        msprime.MassMigration(
+            time=5000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=100000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10,
+        mutation_rate=3e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_temple_guardians())

--- a/stdpopsim/catalog/ForSpa/genome_data.py
+++ b/stdpopsim/catalog/ForSpa/genome_data.py
@@ -1,0 +1,26 @@
+# Genome data for Informis generatus (Formless Spawn)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000034",
+    "assembly_name": "NKAI_SPAWN1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 40000000,
+            "synonyms": ["chr1", "protoplasm_segment_1"],
+        },
+        "II": {
+            "length": 32000000,
+            "synonyms": ["chr2", "protoplasm_segment_2"],
+        },
+        "III": {
+            "length": 25000000,
+            "synonyms": ["chr3", "protoplasm_segment_3"],
+        },
+        "amorphous_element": {
+            "length": 7000,
+            "synonyms": ["mt", "amorphous_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/ForSpa/species.py
+++ b/stdpopsim/catalog/ForSpa/species.py
@@ -1,0 +1,91 @@
+"""
+Species definition for Informis generatus (Formless Spawn).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Formless Spawn have moderate recombination reflecting protoplasmic fluidity.
+# Amorphous element does not recombine.
+_recombination_rate = {
+    "I": 2e-8,
+    "II": 2e-8,
+    "III": 2e-8,
+    "amorphous_element": 0,
+}
+
+# Mutation rates per chromosome.
+# Moderate mutation rate for protoplasmic organisms.
+_mutation_rate = {
+    "I": 3e-8,
+    "II": 3e-8,
+    "III": 3e-8,
+    "amorphous_element": 3e-8,
+}
+
+# Ploidy: diploid for the main chromosomes, haploid for amorphous element.
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "amorphous_element": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="ForSpa",
+    ensembl_id="informis_generatus",
+    name="Informis generatus",
+    common_name="Formless Spawn",
+    genome=_genome,
+    generation_time=10,
+    population_size=25000,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=[
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.formlessspawn.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/GhaShe/__init__.py
+++ b/stdpopsim/catalog/GhaShe/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Ghastus cavernicola
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/GhaShe/demographic_models.py
+++ b/stdpopsim/catalog/GhaShe/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("GhaShe")
+_bone_pop = stdpopsim.Population(id="BoneValley", description="Ghasts in the Vale of Pnath")
+_upper_pop = stdpopsim.Population(id="UpperCaves", description="Upper cave ghast colony")
+
+def _vale_of_pnath():
+    id = "ValeOfPnath_1C26"
+    description = "Single population Vale of Pnath ghast model"
+    long_description = """
+        Single population in the Vale of Pnath. Three epochs: modern
+        scavengers (N=80000), feast-famine cycle 5000 gen ago (N=20000),
+        ancient cave colonization 50000 gen ago (N=150000).
+    """
+    populations = [_bone_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.ghast.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1.8e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=80000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=20000, population_id=0),
+            msprime.PopulationParametersChange(time=50000, initial_size=150000, population_id=0)])
+
+_species.add_demographic_model(_vale_of_pnath())
+
+def _upper_caves():
+    id = "UpperCaves_2C26"
+    description = "Two population Pnath and upper cave model"
+    long_description = """
+        Two populations: Vale of Pnath and upper caves. Ancestral N=150000.
+        Split 15000 gen ago. Pnath at 80000. Upper caves bottleneck to
+        2000, grow to 30000.
+    """
+    populations = [_bone_pop, _upper_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.ghast.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1.8e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=80000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=30000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=3000, initial_size=2000, population_id=1),
+            msprime.MassMigration(time=15000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=15000, initial_size=150000, population_id=0)])
+
+_species.add_demographic_model(_upper_caves())

--- a/stdpopsim/catalog/GhaShe/genome_data.py
+++ b/stdpopsim/catalog/GhaShe/genome_data.py
@@ -1,0 +1,14 @@
+data = {
+    "assembly_accession": "GCA_VOID_000024",
+    "assembly_name": "CAVERN1.0",
+    "chromosomes": {
+        "1": {"length": 40000000, "synonyms": []},
+        "2": {"length": 35000000, "synonyms": []},
+        "3": {"length": 30000000, "synonyms": []},
+        "4": {"length": 25000000, "synonyms": []},
+        "5": {"length": 20000000, "synonyms": []},
+        "carrion_mitogenome": {"length": 14000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/GhaShe/species.py
+++ b/stdpopsim/catalog/GhaShe/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.ghast.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.ghast.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.ghast.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 2e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["carrion_mitogenome"] = 0
+_mutation_rate = {c: 1.8e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["carrion_mitogenome"] = 7e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["carrion_mitogenome"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="GhaShe", ensembl_id="ghastus_cavernicola",
+    name="Ghastus cavernicola", common_name="Ghast",
+    separate_sexes=True, genome=_genome, generation_time=3,
+    population_size=80000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/GnpKeh/__init__.py
+++ b/stdpopsim/catalog/GnpKeh/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Gnophkehus arcticus
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/GnpKeh/demographic_models.py
+++ b/stdpopsim/catalog/GnpKeh/demographic_models.py
@@ -1,0 +1,174 @@
+"""
+Demographic models for Gnophkehus arcticus (Gnoph-Keh).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("GnpKeh")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _hyperborean_ice_age():
+    id = "HyperboreanIceAge_1H33"
+    description = "Hyperborean ice age model for Gnoph-Keh"
+    long_description = """
+        Single population model of Gnoph-Keh population dynamics through
+        the Hyperborean ice ages. Three epochs: (1) a modern phase with
+        effective population size 12000, (2) an ice age expansion period
+        beginning 2000 generations ago with N=50000, and (3) a pre-ice
+        founding era beginning 20000 generations ago with N=5000. Based on
+        the work of Howard et al. (1933).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="Hyperborea",
+            description="Hyperborea -- arctic Gnoph-Keh homeland",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=12000
+    # Ice age expansion at T=2000 gen: N=50000
+    # Pre-ice founding at T=20000 gen: N=5000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=12000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=2000,
+            initial_size=50000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=20000,
+            initial_size=5000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=40,
+        mutation_rate=4e-9,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_hyperborean_ice_age())
+
+
+def _arctic_split():
+    id = "ArcticSplit_2H33"
+    description = "Two population model of Hyperborean Core and Lomar Colony"
+    long_description = """
+        Two population model describing the divergence of the Hyperborean
+        Core and Lomar Colony Gnoph-Keh. The ancestral population of size
+        50000 splits at 5000 generations ago. The Hyperborean Core maintains
+        a size of 12000. The Lomar Colony lineage goes through a bottleneck
+        of 200 individuals before expanding to 6000. Based on the work of
+        Howard et al. (1933).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="HyperboreanCore",
+            description="Hyperborean Core -- primary arctic population",
+        ),
+        stdpopsim.Population(
+            id="LomarColony",
+            description="Lomar Colony -- southern expansion population",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: HyperboreanCore N=12000, LomarColony N=6000
+    # At T=2500 gen ago: LomarColony bottleneck N=200
+    # At T=5000 gen ago: populations merge into ancestral pop N=50000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=12000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=6000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Lomar Colony bottleneck
+        msprime.PopulationParametersChange(
+            time=2500,
+            initial_size=200,
+            population_id=1,
+        ),
+        # At 5000 generations ago, the two populations merge
+        # (LomarColony merge into HyperboreanCore going backwards in time)
+        msprime.MassMigration(
+            time=5000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=50000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=40,
+        mutation_rate=4e-9,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_arctic_split())

--- a/stdpopsim/catalog/GnpKeh/genome_data.py
+++ b/stdpopsim/catalog/GnpKeh/genome_data.py
@@ -1,0 +1,38 @@
+# Genome data for Gnophkehus arcticus (Gnoph-Keh)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000035",
+    "assembly_name": "HYPERBOREA1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 100000000,
+            "synonyms": ["chr1", "horn_segment"],
+        },
+        "II": {
+            "length": 85000000,
+            "synonyms": ["chr2", "limb_pair_1"],
+        },
+        "III": {
+            "length": 70000000,
+            "synonyms": ["chr3", "limb_pair_2"],
+        },
+        "IV": {
+            "length": 60000000,
+            "synonyms": ["chr4", "limb_pair_3"],
+        },
+        "V": {
+            "length": 50000000,
+            "synonyms": ["chr5", "fur_segment"],
+        },
+        "VI": {
+            "length": 40000000,
+            "synonyms": ["chr6", "frost_segment"],
+        },
+        "frost_mitogenome": {
+            "length": 24000,
+            "synonyms": ["mt", "frost_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/GnpKeh/species.py
+++ b/stdpopsim/catalog/GnpKeh/species.py
@@ -1,0 +1,100 @@
+"""
+Species definition for Gnophkehus arcticus (Gnoph-Keh).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Gnoph-Keh have low recombination reflecting ancient arctic genome stability.
+# Frost mitogenome does not recombine.
+_recombination_rate = {
+    "I": 3e-9,
+    "II": 3e-9,
+    "III": 3e-9,
+    "IV": 3e-9,
+    "V": 3e-9,
+    "VI": 3e-9,
+    "frost_mitogenome": 0,
+}
+
+# Mutation rates per chromosome.
+# Low mutation rate for long-lived arctic organisms.
+_mutation_rate = {
+    "I": 4e-9,
+    "II": 4e-9,
+    "III": 4e-9,
+    "IV": 4e-9,
+    "V": 4e-9,
+    "VI": 4e-9,
+    "frost_mitogenome": 4e-9,
+}
+
+# Ploidy: diploid for the main chromosomes, haploid for frost mitogenome.
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "V": _species_ploidy,
+    "VI": _species_ploidy,
+    "frost_mitogenome": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="GnpKeh",
+    ensembl_id="gnophkehus_arcticus",
+    name="Gnophkehus arcticus",
+    common_name="Gnoph-Keh",
+    genome=_genome,
+    generation_time=40,
+    population_size=12000,
+    ploidy=_species_ploidy,
+    separate_sexes=True,
+    citations=[
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Howard et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.gnophkeh.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/GugsUn/__init__.py
+++ b/stdpopsim/catalog/GugsUn/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Gugus underworldis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/GugsUn/demographic_models.py
+++ b/stdpopsim/catalog/GugsUn/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("GugsUn")
+_vault_pop = stdpopsim.Population(id="VaultDwellers", description="Gugs in the vaults of Zin")
+_tower_pop = stdpopsim.Population(id="TowerGugs", description="Gugs near the Tower of Koth")
+
+def _vault_exile():
+    id = "VaultExile_1C26"
+    description = "Single population Gug vault exile model"
+    long_description = """
+        Single population of exiled Gugs. Three epochs: modern vault
+        (N=25000), post-banishment bottleneck 3000 gen ago (N=2000),
+        surface era before exile 30000 gen ago (N=200000).
+    """
+    populations = [_vault_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.gug.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=5e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=25000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=3000, initial_size=2000, population_id=0),
+            msprime.PopulationParametersChange(time=30000, initial_size=200000, population_id=0)])
+
+_species.add_demographic_model(_vault_exile())
+
+def _tower_split():
+    id = "TowerSplit_2C26"
+    description = "Two population vault and Tower of Koth model"
+    long_description = """
+        Two populations: vault dwellers and Tower of Koth gugs. Ancestral
+        N=200000. Split 10000 gen ago. Vault at 25000. Tower bottleneck
+        to 500, grow to 10000.
+    """
+    populations = [_vault_pop, _tower_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.gug.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=5e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=25000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=10000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=2000, initial_size=500, population_id=1),
+            msprime.MassMigration(time=10000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=10000, initial_size=200000, population_id=0)])
+
+_species.add_demographic_model(_tower_split())

--- a/stdpopsim/catalog/GugsUn/genome_data.py
+++ b/stdpopsim/catalog/GugsUn/genome_data.py
@@ -1,0 +1,13 @@
+data = {
+    "assembly_accession": "GCA_VOID_000023",
+    "assembly_name": "UNDERWORLD1.0",
+    "chromosomes": {
+        "I": {"length": 200000000, "synonyms": []},
+        "II": {"length": 180000000, "synonyms": []},
+        "III": {"length": 160000000, "synonyms": []},
+        "IV": {"length": 140000000, "synonyms": []},
+        "gug_mitogenome": {"length": 35000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/GugsUn/species.py
+++ b/stdpopsim/catalog/GugsUn/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.gug.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.gug.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.gug.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 6e-9 for c in genome_data.data["chromosomes"]}
+_recombination_rate["gug_mitogenome"] = 0
+_mutation_rate = {c: 5e-9 for c in genome_data.data["chromosomes"]}
+_mutation_rate["gug_mitogenome"] = 2e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["gug_mitogenome"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="GugsUn", ensembl_id="gugus_underworldis",
+    name="Gugus underworldis", common_name="Gug",
+    separate_sexes=True, genome=_genome, generation_time=30,
+    population_size=25000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/HouFir/__init__.py
+++ b/stdpopsim/catalog/HouFir/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Houndus tindalosi
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/HouFir/demographic_models.py
+++ b/stdpopsim/catalog/HouFir/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("HouFir")
+_angular_pop = stdpopsim.Population(id="AngularRealm", description="Hounds dwelling in angular time")
+_corner_pop = stdpopsim.Population(id="CornerHunters", description="Hounds that emerged through corners")
+
+def _angular_time():
+    id = "AngularTime_1L29"
+    description = "Single population angular time predator model"
+    long_description = """
+        Single population of Hounds existing in angular time. Three epochs:
+        modern scattered hunters (N=5000), temporal convergence 500 gen ago
+        (N=20000), primordial angular existence 5000 gen ago (N=1000).
+    """
+    populations = [_angular_pop]
+    citations = [stdpopsim.Citation(author="Long et al.", year=1929,
+        doi="https://doi.org/10.1666/void.tindalos.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=3e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=5000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=500, initial_size=20000, population_id=0),
+            msprime.PopulationParametersChange(time=5000, initial_size=1000, population_id=0)])
+
+_species.add_demographic_model(_angular_time())
+
+def _corner_emergence():
+    id = "CornerEmergence_2L29"
+    description = "Two population angular realm and corner hunters model"
+    long_description = """
+        Two populations: angular realm dwellers and corner-emerged hunters.
+        Ancestral N=20000. Split 1000 gen ago. Angular realm at 5000.
+        Corner hunters bottleneck to 100, expand to 3000.
+    """
+    populations = [_angular_pop, _corner_pop]
+    citations = [stdpopsim.Citation(author="Long et al.", year=1929,
+        doi="https://doi.org/10.1666/void.tindalos.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=3e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=5000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=3000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=200, initial_size=100, population_id=1),
+            msprime.MassMigration(time=1000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=1000, initial_size=20000, population_id=0)])
+
+_species.add_demographic_model(_corner_emergence())

--- a/stdpopsim/catalog/HouFir/genome_data.py
+++ b/stdpopsim/catalog/HouFir/genome_data.py
@@ -1,0 +1,12 @@
+data = {
+    "assembly_accession": "GCA_VOID_000014",
+    "assembly_name": "ANGULAR1.0",
+    "chromosomes": {
+        "I": {"length": 60000000, "synonyms": []},
+        "II": {"length": 55000000, "synonyms": []},
+        "III": {"length": 50000000, "synonyms": []},
+        "angular_genome": {"length": 25000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/HouFir/species.py
+++ b/stdpopsim/catalog/HouFir/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Long et al.", year=1929,
+    doi="https://doi.org/10.1666/void.tindalos.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Long et al.", year=1929,
+    doi="https://doi.org/10.1666/void.tindalos.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Long et al.", year=1929,
+    doi="https://doi.org/10.1666/void.tindalos.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 5e-9 for c in genome_data.data["chromosomes"]}
+_recombination_rate["angular_genome"] = 0
+_mutation_rate = {c: 3e-9 for c in genome_data.data["chromosomes"]}
+_mutation_rate["angular_genome"] = 1e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["angular_genome"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="HouFir", ensembl_id="houndus_tindalosi",
+    name="Houndus tindalosi", common_name="Hound of Tindalos",
+    separate_sexes=False, genome=_genome, generation_time=500,
+    population_size=5000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/HunTin/__init__.py
+++ b/stdpopsim/catalog/HunTin/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Venator obscurus
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/HunTin/demographic_models.py
+++ b/stdpopsim/catalog/HunTin/demographic_models.py
@@ -1,0 +1,171 @@
+"""
+Demographic models for Venator obscurus (Hunting Horror).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("HunTin")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _dark_flight():
+    id = "DarkFlight_1M33"
+    description = "Three epoch model of Hunting Horror dark flight populations"
+    long_description = """
+        Single population model of Hunting Horrors serving Nyarlathotep.
+        Three epochs: (1) a modern phase with effective population size 15000,
+        (2) a Nyarlathotep summoning boom beginning 2000 generations ago with
+        N=3000, and (3) an ancient void origin beginning 20000 generations ago
+        with N=50000. Based on the studies of deMarigny et al. (1933).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="DarkFlyers",
+            description="Hunting Horrors -- dark serpentine flyers of the void",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=15000
+    # Nyarlathotep summoning boom at T=2000 gen: N=3000
+    # Ancient void origin at T=20000 gen: N=50000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=15000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=2000,
+            initial_size=3000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=20000,
+            initial_size=50000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=20,
+        mutation_rate=6e-9,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_dark_flight())
+
+
+def _nyarlathotep_service():
+    id = "NyarlathService_2M33"
+    description = "Two population model of Void Hunters and Earthbound Sentinels"
+    long_description = """
+        Two population model describing the divergence of Void Hunters and
+        Earthbound Sentinels. The ancestral population of size 50000 splits at
+        5000 generations ago. The Void Hunter population maintains a size of
+        15000. The Earthbound Sentinel lineage goes through a bottleneck of 200
+        individuals before expanding to 5000. Based on deMarigny et al. (1933).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="VoidHunters",
+            description="Void Hunters -- Hunting Horrors of the outer dark",
+        ),
+        stdpopsim.Population(
+            id="EarthboundSentinels",
+            description="Earthbound Sentinels -- terrestrial Hunting Horrors",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: VoidHunters N=15000, EarthboundSentinels N=5000
+    # At T=1000 gen ago: EarthboundSentinels bottleneck N=200
+    # At T=5000 gen ago: populations merge into ancestral pop N=50000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=15000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=5000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Earthbound Sentinel bottleneck at 1000 generations ago
+        msprime.PopulationParametersChange(
+            time=1000,
+            initial_size=200,
+            population_id=1,
+        ),
+        # At 5000 generations ago, the two populations merge
+        msprime.MassMigration(
+            time=5000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=50000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=20,
+        mutation_rate=6e-9,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_nyarlathotep_service())

--- a/stdpopsim/catalog/HunTin/genome_data.py
+++ b/stdpopsim/catalog/HunTin/genome_data.py
@@ -1,0 +1,30 @@
+# Genome data for Venator obscurus (Hunting Horror)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000026",
+    "assembly_name": "DARKFLIGHT1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 80000000,
+            "synonyms": ["chr1", "serpentine_1"],
+        },
+        "II": {
+            "length": 65000000,
+            "synonyms": ["chr2", "serpentine_2"],
+        },
+        "III": {
+            "length": 50000000,
+            "synonyms": ["chr3", "serpentine_3"],
+        },
+        "IV": {
+            "length": 40000000,
+            "synonyms": ["chr4", "serpentine_4"],
+        },
+        "shadow_element": {
+            "length": 10000,
+            "synonyms": ["mt", "dark_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/HunTin/species.py
+++ b/stdpopsim/catalog/HunTin/species.py
@@ -1,0 +1,95 @@
+"""
+Species definition for Venator obscurus (Hunting Horror).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Hunting Horrors have moderate recombination reflecting
+# their dark serpentine genomic architecture.
+# Shadow element does not recombine.
+_recombination_rate = {
+    "I": 4e-9,
+    "II": 4e-9,
+    "III": 4e-9,
+    "IV": 4e-9,
+    "shadow_element": 0,
+}
+
+# Mutation rates per chromosome.
+# Moderate mutation rate for void-dwelling serpentine flyers.
+_mutation_rate = {
+    "I": 6e-9,
+    "II": 6e-9,
+    "III": 6e-9,
+    "IV": 6e-9,
+    "shadow_element": 6e-9,
+}
+
+# Ploidy: diploid for main chromosomes, haploid for shadow element.
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "shadow_element": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="HunTin",
+    ensembl_id="venator_obscurus",
+    name="Venator obscurus",
+    common_name="Hunting Horror",
+    genome=_genome,
+    generation_time=20,
+    population_size=15000,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=[
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="deMarigny et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.huntin.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/LenSpi/__init__.py
+++ b/stdpopsim/catalog/LenSpi/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Araneus lengensis
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/LenSpi/demographic_models.py
+++ b/stdpopsim/catalog/LenSpi/demographic_models.py
@@ -1,0 +1,172 @@
+"""
+Demographic models for Araneus lengensis (Leng Spider).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("LenSpi")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _plateau_dominion():
+    id = "PlateauDominion_1C26"
+    description = "Three epoch model of Leng Spider plateau dominion"
+    long_description = """
+        Single population model of the Leng Spiders on the Plateau of Leng.
+        Three epochs: (1) a modern phase with effective population size 20000,
+        (2) a slave trade expansion beginning 5000 generations ago with N=5000,
+        and (3) an ancient colonization era beginning 50000 generations ago
+        with N=60000. Based on the studies of Carter et al. (1926).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="LengSpiders",
+            description="Leng Spiders -- giant purple arachnids of the plateau",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=20000
+    # Slave trade expansion at T=5000 gen: N=5000
+    # Ancient colonization at T=50000 gen: N=60000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=20000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=5000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=50000,
+            initial_size=60000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10,
+        mutation_rate=1e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_plateau_dominion())
+
+
+def _web_network():
+    id = "WebNetwork_2C26"
+    description = "Two population model of Plateau Core and Vale Outpost Leng Spiders"
+    long_description = """
+        Two population model describing the divergence of Plateau Core and
+        Vale Outpost Leng Spider populations. The ancestral population of size
+        60000 splits at 15000 generations ago. The Plateau Core population
+        maintains a size of 20000. The Vale Outpost lineage goes through a
+        bottleneck of 300 individuals before expanding to 8000. Based on
+        Carter et al. (1926).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="PlateauCore",
+            description="Plateau Core -- central Leng Spider civilization",
+        ),
+        stdpopsim.Population(
+            id="ValeOutposts",
+            description="Vale Outposts -- peripheral Leng Spider settlements",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: PlateauCore N=20000, ValeOutposts N=8000
+    # At T=5000 gen ago: ValeOutposts bottleneck N=300
+    # At T=15000 gen ago: populations merge into ancestral pop N=60000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=20000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=8000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Vale Outpost bottleneck at 5000 generations ago
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=300,
+            population_id=1,
+        ),
+        # At 15000 generations ago, the two populations merge
+        msprime.MassMigration(
+            time=15000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=15000,
+            initial_size=60000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10,
+        mutation_rate=1e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_web_network())

--- a/stdpopsim/catalog/LenSpi/genome_data.py
+++ b/stdpopsim/catalog/LenSpi/genome_data.py
@@ -1,0 +1,34 @@
+# Genome data for Araneus lengensis (Leng Spider)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000028",
+    "assembly_name": "LENG1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 60000000,
+            "synonyms": ["chr1", "silk_1"],
+        },
+        "II": {
+            "length": 52000000,
+            "synonyms": ["chr2", "silk_2"],
+        },
+        "III": {
+            "length": 45000000,
+            "synonyms": ["chr3", "silk_3"],
+        },
+        "IV": {
+            "length": 38000000,
+            "synonyms": ["chr4", "silk_4"],
+        },
+        "V": {
+            "length": 30000000,
+            "synonyms": ["chr5", "silk_5"],
+        },
+        "silk_mitogenome": {
+            "length": 20000,
+            "synonyms": ["mt", "silk_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/LenSpi/species.py
+++ b/stdpopsim/catalog/LenSpi/species.py
@@ -1,0 +1,98 @@
+"""
+Species definition for Araneus lengensis (Leng Spider).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Leng Spiders have moderate recombination reflecting
+# their complex web-spinning genomic architecture.
+# Silk mitogenome does not recombine.
+_recombination_rate = {
+    "I": 8e-9,
+    "II": 8e-9,
+    "III": 8e-9,
+    "IV": 8e-9,
+    "V": 8e-9,
+    "silk_mitogenome": 0,
+}
+
+# Mutation rates per chromosome.
+# Moderate mutation rate for intelligent arachnid species.
+_mutation_rate = {
+    "I": 1e-8,
+    "II": 1e-8,
+    "III": 1e-8,
+    "IV": 1e-8,
+    "V": 1e-8,
+    "silk_mitogenome": 1e-8,
+}
+
+# Ploidy: diploid for main chromosomes, haploid for silk mitogenome.
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "V": _species_ploidy,
+    "silk_mitogenome": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="LenSpi",
+    ensembl_id="araneus_lengensis",
+    name="Araneus lengensis",
+    common_name="Leng Spider",
+    genome=_genome,
+    generation_time=10,
+    population_size=20000,
+    ploidy=_species_ploidy,
+    separate_sexes=True,
+    citations=[
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Carter et al.",
+            year=1926,
+            doi="https://doi.org/10.1666/void.lenspi.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/MooFun/__init__.py
+++ b/stdpopsim/catalog/MooFun/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Lunaris bestialis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/MooFun/demographic_models.py
+++ b/stdpopsim/catalog/MooFun/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("MooFun")
+_dark_pop = stdpopsim.Population(id="DarkSideMoon", description="Moon-beasts on the dark side of the moon")
+_trade_pop = stdpopsim.Population(id="TradeFleet", description="Moon-beast trading fleet in Dreamlands")
+
+def _dark_side():
+    id = "DarkSideDominion_1C26"
+    description = "Single population dark side of the moon model"
+    long_description = """
+        Single population on the moon's dark side. Three epochs: modern
+        slavers (N=45000), expansion from trade routes 5000 gen ago
+        (N=10000), ancient lunar origin 50000 gen ago (N=80000).
+    """
+    populations = [_dark_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.moonbeast.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1.2e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=45000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=10000, population_id=0),
+            msprime.PopulationParametersChange(time=50000, initial_size=80000, population_id=0)])
+
+_species.add_demographic_model(_dark_side())
+
+def _trade_fleet():
+    id = "TradeFleet_2C26"
+    description = "Two population moon and Dreamlands trading fleet model"
+    long_description = """
+        Two populations: dark side homeworld and Dreamlands trading fleet.
+        Ancestral N=80000. Split 10000 gen ago. Moon at 45000. Trading
+        fleet bottleneck to 500, grow to 15000.
+    """
+    populations = [_dark_pop, _trade_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.moonbeast.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1.2e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=45000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=15000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=2000, initial_size=500, population_id=1),
+            msprime.MassMigration(time=10000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=10000, initial_size=80000, population_id=0)])
+
+_species.add_demographic_model(_trade_fleet())

--- a/stdpopsim/catalog/MooFun/genome_data.py
+++ b/stdpopsim/catalog/MooFun/genome_data.py
@@ -1,0 +1,13 @@
+data = {
+    "assembly_accession": "GCA_VOID_000020",
+    "assembly_name": "DARKMOON1.0",
+    "chromosomes": {
+        "I": {"length": 55000000, "synonyms": []},
+        "II": {"length": 50000000, "synonyms": []},
+        "III": {"length": 45000000, "synonyms": []},
+        "IV": {"length": 40000000, "synonyms": []},
+        "lunar_element": {"length": 12000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/MooFun/species.py
+++ b/stdpopsim/catalog/MooFun/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.moonbeast.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.moonbeast.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.moonbeast.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 1.5e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["lunar_element"] = 0
+_mutation_rate = {c: 1.2e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["lunar_element"] = 6e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["lunar_element"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="MooFun", ensembl_id="lunaris_bestialis",
+    name="Lunaris bestialis", common_name="Moon-Beast",
+    separate_sexes=False, genome=_genome, generation_time=8,
+    population_size=45000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/NigMan/__init__.py
+++ b/stdpopsim/catalog/NigMan/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Nightgauntus mantaformis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/NigMan/demographic_models.py
+++ b/stdpopsim/catalog/NigMan/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("NigMan")
+_peak_pop = stdpopsim.Population(id="NophorPeaks", description="Nightgaunts of Ngranek peaks")
+_dream_pop = stdpopsim.Population(id="DreamVoid", description="Dream void nightgaunt colony")
+
+def _ngranek_flock():
+    id = "NgranekFlock_1C26"
+    description = "Single population Ngranek peak colony model"
+    long_description = """
+        Single population of nightgaunts on Ngranek. Three epochs:
+        modern flock (N=75000), expansion from Nodens' service 5000 gen
+        ago (N=10000), ancient dreamlands origin 50000 gen ago (N=100000).
+    """
+    populations = [_peak_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.nightgaunt.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=2e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=75000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=10000, population_id=0),
+            msprime.PopulationParametersChange(time=50000, initial_size=100000, population_id=0)])
+
+_species.add_demographic_model(_ngranek_flock())
+
+def _dream_split():
+    id = "DreamVoidSplit_2C26"
+    description = "Two population Ngranek and dream void model"
+    long_description = """
+        Two populations: Ngranek peaks and dream void colony. Ancestral
+        N=100000. Split 20000 gen ago. Peaks stable at 75000. Void colony
+        bottleneck to 500 then expand to 40000.
+    """
+    populations = [_peak_pop, _dream_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.nightgaunt.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=2e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=75000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=40000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=500, population_id=1),
+            msprime.MassMigration(time=20000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=20000, initial_size=100000, population_id=0)])
+
+_species.add_demographic_model(_dream_split())

--- a/stdpopsim/catalog/NigMan/genome_data.py
+++ b/stdpopsim/catalog/NigMan/genome_data.py
@@ -1,0 +1,15 @@
+data = {
+    "assembly_accession": "GCA_VOID_000013",
+    "assembly_name": "DREAMFLIGHT1.0",
+    "chromosomes": {
+        "I": {"length": 45000000, "synonyms": []},
+        "II": {"length": 40000000, "synonyms": []},
+        "III": {"length": 35000000, "synonyms": []},
+        "IV": {"length": 30000000, "synonyms": []},
+        "V": {"length": 25000000, "synonyms": []},
+        "VI": {"length": 20000000, "synonyms": []},
+        "faceless_element": {"length": 15000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/NigMan/species.py
+++ b/stdpopsim/catalog/NigMan/species.py
@@ -1,0 +1,30 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.nightgaunt.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.nightgaunt.2",
+    reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.nightgaunt.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 1.8e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["faceless_element"] = 0
+_mutation_rate = {c: 2e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["faceless_element"] = 5e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["faceless_element"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="NigMan", ensembl_id="nightgauntus_mantaformis",
+    name="Nightgauntus mantaformis", common_name="Nightgaunt",
+    separate_sexes=False, genome=_genome, generation_time=5,
+    population_size=75000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/RatThi/__init__.py
+++ b/stdpopsim/catalog/RatThi/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Rattus magicus
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/RatThi/demographic_models.py
+++ b/stdpopsim/catalog/RatThi/demographic_models.py
@@ -1,0 +1,174 @@
+"""
+Demographic models for Rattus magicus (Rat-Thing).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("RatThi")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _witch_house_plague():
+    id = "WitchHousePlague_1G32"
+    description = "Witch trial purge model for Rat-Things"
+    long_description = """
+        Single population model of Rat-Thing population dynamics through
+        witch trial eras. Three epochs: (1) a modern phase with effective
+        population size 50000, (2) a witch trial purge period beginning 500
+        generations ago with N=1000, and (3) a colonial era beginning 2000
+        generations ago with N=100000. Based on the work of Gilman et al.
+        (1932).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="WitchHouse",
+            description="Witch House colony -- Rat-Things in Arkham",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=50000
+    # Witch trial purge at T=500 gen: N=1000
+    # Colonial era at T=2000 gen: N=100000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=50000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=500,
+            initial_size=1000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=2000,
+            initial_size=100000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=1,
+        mutation_rate=2e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_witch_house_plague())
+
+
+def _familiar_lineage():
+    id = "FamiliarLineage_2G32"
+    description = "Two population model of Feral Colony and Witch-Bound Rat-Things"
+    long_description = """
+        Two population model describing the divergence of the Feral Colony
+        and Witch-Bound Rat-Things. The ancestral population of size 100000
+        splits at 1000 generations ago. The Feral Colony maintains a size
+        of 50000. The Witch-Bound lineage goes through a bottleneck of 100
+        individuals before expanding to 10000. Based on the work of Gilman
+        et al. (1932).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="FeralColony",
+            description="Feral Colony -- free-roaming Rat-Things",
+        ),
+        stdpopsim.Population(
+            id="WitchBound",
+            description="Witch-Bound -- familiar Rat-Things",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: FeralColony N=50000, WitchBound N=10000
+    # At T=500 gen ago: WitchBound bottleneck N=100
+    # At T=1000 gen ago: populations merge into ancestral pop N=100000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=50000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=10000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Witch-Bound bottleneck
+        msprime.PopulationParametersChange(
+            time=500,
+            initial_size=100,
+            population_id=1,
+        ),
+        # At 1000 generations ago, the two populations merge
+        # (WitchBound merge into FeralColony going backwards in time)
+        msprime.MassMigration(
+            time=1000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=1000,
+            initial_size=100000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=1,
+        mutation_rate=2e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_familiar_lineage())

--- a/stdpopsim/catalog/RatThi/genome_data.py
+++ b/stdpopsim/catalog/RatThi/genome_data.py
@@ -1,0 +1,42 @@
+# Genome data for Rattus magicus (Rat-Thing)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000033",
+    "assembly_name": "WITCHHOUSE1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "1": {
+            "length": 50000000,
+            "synonyms": ["chr1", "familiar_segment_1"],
+        },
+        "2": {
+            "length": 45000000,
+            "synonyms": ["chr2", "familiar_segment_2"],
+        },
+        "3": {
+            "length": 40000000,
+            "synonyms": ["chr3", "familiar_segment_3"],
+        },
+        "4": {
+            "length": 35000000,
+            "synonyms": ["chr4", "humanface_segment"],
+        },
+        "5": {
+            "length": 30000000,
+            "synonyms": ["chr5", "paw_segment"],
+        },
+        "6": {
+            "length": 25000000,
+            "synonyms": ["chr6", "tail_segment"],
+        },
+        "7": {
+            "length": 20000000,
+            "synonyms": ["chr7", "whisker_segment"],
+        },
+        "witch_mitogenome": {
+            "length": 16000,
+            "synonyms": ["mt", "witch_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/RatThi/species.py
+++ b/stdpopsim/catalog/RatThi/species.py
@@ -1,0 +1,103 @@
+"""
+Species definition for Rattus magicus (Rat-Thing).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Rat-Things have moderate recombination typical of small mammals.
+# Witch mitogenome does not recombine.
+_recombination_rate = {
+    "1": 1.5e-8,
+    "2": 1.5e-8,
+    "3": 1.5e-8,
+    "4": 1.5e-8,
+    "5": 1.5e-8,
+    "6": 1.5e-8,
+    "7": 1.5e-8,
+    "witch_mitogenome": 0,
+}
+
+# Mutation rates per chromosome.
+# Moderate mutation rate similar to terrestrial rodents.
+_mutation_rate = {
+    "1": 2e-8,
+    "2": 2e-8,
+    "3": 2e-8,
+    "4": 2e-8,
+    "5": 2e-8,
+    "6": 2e-8,
+    "7": 2e-8,
+    "witch_mitogenome": 2e-8,
+}
+
+# Ploidy: diploid for the main chromosomes, haploid for witch mitogenome.
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "witch_mitogenome": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="RatThi",
+    ensembl_id="rattus_magicus",
+    name="Rattus magicus",
+    common_name="Rat-Thing",
+    genome=_genome,
+    generation_time=1,
+    population_size=50000,
+    ploidy=_species_ploidy,
+    separate_sexes=True,
+    citations=[
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Gilman et al.",
+            year=1932,
+            doi="https://doi.org/10.1666/void.ratthing.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/SanDre/__init__.py
+++ b/stdpopsim/catalog/SanDre/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Shantakus dreamlandis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/SanDre/demographic_models.py
+++ b/stdpopsim/catalog/SanDre/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("SanDre")
+_kadath_pop = stdpopsim.Population(id="KadathPeaks", description="Shantaks nesting on Kadath peaks")
+_plateau_pop = stdpopsim.Population(id="LengPlateau", description="Shantaks of the Plateau of Leng")
+
+def _kadath_nesting():
+    id = "KadathNesting_1C26"
+    description = "Single population Kadath nesting colony model"
+    long_description = """
+        Single population on Kadath peaks. Three epochs: modern flock
+        (N=60000), taming by moon-beasts 3000 gen ago (N=20000),
+        wild ancestral flock 30000 gen ago (N=150000).
+    """
+    populations = [_kadath_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.shantak.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1.5e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=60000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=3000, initial_size=20000, population_id=0),
+            msprime.PopulationParametersChange(time=30000, initial_size=150000, population_id=0)])
+
+_species.add_demographic_model(_kadath_nesting())
+
+def _leng_split():
+    id = "LengSplit_2C26"
+    description = "Two population Kadath and Leng shantak model"
+    long_description = """
+        Two populations: Kadath peaks and Leng plateau. Ancestral N=150000.
+        Split 10000 gen ago. Kadath at 60000. Leng bottleneck to 300,
+        grow to 25000.
+    """
+    populations = [_kadath_pop, _plateau_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.shantak.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1.5e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=60000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=25000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=2000, initial_size=300, population_id=1),
+            msprime.MassMigration(time=10000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=10000, initial_size=150000, population_id=0)])
+
+_species.add_demographic_model(_leng_split())

--- a/stdpopsim/catalog/SanDre/genome_data.py
+++ b/stdpopsim/catalog/SanDre/genome_data.py
@@ -1,0 +1,14 @@
+data = {
+    "assembly_accession": "GCA_VOID_000019",
+    "assembly_name": "KADATH1.0",
+    "chromosomes": {
+        "I": {"length": 75000000, "synonyms": []},
+        "II": {"length": 65000000, "synonyms": []},
+        "III": {"length": 55000000, "synonyms": []},
+        "IV": {"length": 45000000, "synonyms": []},
+        "V": {"length": 35000000, "synonyms": []},
+        "scale_mitogenome": {"length": 22000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/SanDre/species.py
+++ b/stdpopsim/catalog/SanDre/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.shantak.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.shantak.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.shantak.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 2e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["scale_mitogenome"] = 0
+_mutation_rate = {c: 1.5e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["scale_mitogenome"] = 4e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["scale_mitogenome"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="SanDre", ensembl_id="shantakus_dreamlandis",
+    name="Shantakus dreamlandis", common_name="Shantak",
+    separate_sexes=True, genome=_genome, generation_time=15,
+    population_size=60000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/SanDwl/__init__.py
+++ b/stdpopsim/catalog/SanDwl/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Arenicola abyssalis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/SanDwl/demographic_models.py
+++ b/stdpopsim/catalog/SanDwl/demographic_models.py
@@ -1,0 +1,186 @@
+"""
+Demographic models for Arenicola abyssalis (Sand Dweller).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+
+import stdpopsim
+
+_species = stdpopsim.get_species("SanDwl")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+# Fictional citations for stdvoidsim
+
+_alhazred_et_al = stdpopsim.Citation(
+    author="Alhazred et al.",
+    year=730,
+    doi="https://doi.org/10.1666/void.sanddweller.demog.1",
+    reasons={stdpopsim.CiteReason.DEM_MODEL},
+)
+
+
+# -------------------------------------------------------------------------
+# DesertBurrowers_1A730: Single population three-epoch model
+# -------------------------------------------------------------------------
+
+
+def _desert_burrowers():
+    id = "DesertBurrowers_1A730"
+    description = "Single population three-epoch model of Sand Dwellers"
+    long_description = """
+        Single population model of Sand Dweller demographic history. Three
+        epochs: modern desert population with effective population size 40,000,
+        an oasis bottleneck beginning 3,000 generations ago with N=8,000,
+        and an ancient Irem era beginning 30,000 generations ago with
+        N=120,000. Based on the Necronomicon surveys of Alhazred et al. (730).
+    """
+    citations = [_alhazred_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="SandDwellers",
+            description="Sand Dwellers of the Empty Quarter",
+        ),
+    ]
+
+    # Modern desert: N=40,000
+    # Oasis bottleneck at T=3,000 gen: N=8,000
+    # Ancient Irem era at T=30,000 gen: N=120,000
+    N_modern = 40000
+    N_oasis = 8000
+    N_ancient = 120000
+
+    T_oasis = 3000
+    T_irem = 30000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_modern,
+            metadata={
+                "name": "SandDwellers",
+                "description": "Sand Dwellers of the Empty Quarter",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=T_oasis, initial_size=N_oasis, population_id=0
+        ),
+        msprime.PopulationParametersChange(
+            time=T_irem, initial_size=N_ancient, population_id=0
+        ),
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=15,
+        mutation_rate=1.2e-8,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=[[0]],
+    )
+
+
+_species.add_demographic_model(_desert_burrowers())
+
+
+# -------------------------------------------------------------------------
+# IremRuins_2A730: Two population model
+# -------------------------------------------------------------------------
+
+
+def _irem_ruins():
+    id = "IremRuins_2A730"
+    description = "Two-population model of Deep Desert and Ruin Dwellers"
+    long_description = """
+        Two-population model representing Deep Desert Sand Dwellers and
+        Ruin Dwellers of Irem. An ancestral population of size 120,000
+        splits at 10,000 generations ago. The Deep Desert population
+        maintains a size of 40,000. The Ruin Dwellers go through a
+        bottleneck of 400 individuals before expanding to 15,000 in the
+        present day. Based on the Necronomicon surveys of Alhazred et al.
+        (730).
+    """
+    citations = [_alhazred_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="DeepDesert",
+            description="Deep Desert Sand Dwellers -- nomadic burrowers",
+        ),
+        stdpopsim.Population(
+            id="RuinDwellers",
+            description="Ruin Dwellers of Irem -- settled colony",
+        ),
+    ]
+
+    # Parameters
+    N_ancestral = 120000
+    N_desert = 40000
+    N_ruins_modern = 15000
+    N_ruins_bottleneck = 400
+    T_split = 10000
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_desert,
+            metadata={
+                "name": "DeepDesert",
+                "description": "Deep Desert Sand Dwellers -- nomadic burrowers",
+            },
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=N_ruins_modern,
+            metadata={
+                "name": "RuinDwellers",
+                "description": "Ruin Dwellers of Irem -- settled colony",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        # Ruin Dwellers bottleneck right after the split
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_ruins_bottleneck, population_id=1
+        ),
+        # Split: Ruin Dwellers merge back into Deep Desert at T_split
+        msprime.MassMigration(
+            time=T_split, source=1, destination=0, proportion=1.0
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_ancestral, population_id=0
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=15,
+        mutation_rate=1.2e-8,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=migration_matrix,
+    )
+
+
+_species.add_demographic_model(_irem_ruins())

--- a/stdpopsim/catalog/SanDwl/genome_data.py
+++ b/stdpopsim/catalog/SanDwl/genome_data.py
@@ -1,0 +1,30 @@
+# Genome data for Arenicola abyssalis (Sand Dweller)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000037",
+    "assembly_name": "IREM1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 55000000,
+            "synonyms": ["chr1", "burrow_segment_1"],
+        },
+        "II": {
+            "length": 45000000,
+            "synonyms": ["chr2", "burrow_segment_2"],
+        },
+        "III": {
+            "length": 35000000,
+            "synonyms": ["chr3", "desiccation_arm"],
+        },
+        "IV": {
+            "length": 30000000,
+            "synonyms": ["chr4", "sand_filter"],
+        },
+        "desert_element": {
+            "length": 9000,
+            "synonyms": ["mt", "desert_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/SanDwl/species.py
+++ b/stdpopsim/catalog/SanDwl/species.py
@@ -1,0 +1,69 @@
+"""
+Species definition for Arenicola abyssalis (Sand Dweller).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Fictional citations for stdvoidsim
+
+_alhazred_et_al = stdpopsim.Citation(
+    author="Alhazred et al.",
+    year=730,
+    doi="https://doi.org/10.1666/void.sanddweller.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+
+_alhazred_genome_ref = stdpopsim.Citation(
+    author="Alhazred et al.",
+    year=730,
+    doi="https://doi.org/10.1666/void.sanddweller.assembly.1",
+    reasons={
+        stdpopsim.CiteReason.ASSEMBLY,
+        stdpopsim.CiteReason.MUT_RATE,
+        stdpopsim.CiteReason.REC_RATE,
+    },
+)
+
+_genome_citations = [_alhazred_genome_ref]
+_species_citations = [_alhazred_et_al, _alhazred_genome_ref]
+
+# Chromosome-level mutation rate (~1.2e-8 per base per generation)
+_overall_mutation_rate = 1.2e-8
+
+# Chromosome-level recombination rate (~9e-9 per base per generation)
+_overall_recombination_rate = 9e-9
+
+_chromosome_names = list(genome_data.data["chromosomes"].keys())
+
+_mutation_rate = {name: _overall_mutation_rate for name in _chromosome_names}
+
+_recombination_rate = {name: _overall_recombination_rate for name in _chromosome_names}
+
+# Ploidy of 2 for all chromosomes (diploid)
+_ploidy = {name: 2 for name in _chromosome_names}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=_genome_citations,
+)
+
+_species = stdpopsim.Species(
+    id="SanDwl",
+    ensembl_id="arenicola_abyssalis",
+    name="Arenicola abyssalis",
+    common_name="Sand Dweller",
+    genome=_genome,
+    generation_time=15,
+    population_size=40000,
+    ploidy=2,
+    separate_sexes=False,
+    citations=_species_citations,
+)
+
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/SerHum/__init__.py
+++ b/stdpopsim/catalog/SerHum/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Serpentis valusiensis
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/SerHum/demographic_models.py
+++ b/stdpopsim/catalog/SerHum/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("SerHum")
+_valusia_pop = stdpopsim.Population(id="Valusia", description="Ancient Valusian serpent empire")
+_infiltrator_pop = stdpopsim.Population(id="Infiltrators", description="Human-disguised infiltrators")
+
+def _valusian_empire():
+    id = "ValusianEmpire_1K29"
+    description = "Single population Valusian empire decline model"
+    long_description = """
+        Single population of serpent people. Three epochs: modern hidden
+        remnants (N=40000), post-Kull persecution 2000 gen ago (N=5000),
+        golden Valusian empire 20000 gen ago (N=500000).
+    """
+    populations = [_valusia_pop]
+    citations = [stdpopsim.Citation(author="Kull et al.", year=1929,
+        doi="https://doi.org/10.1666/void.serpent.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=40000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=2000, initial_size=5000, population_id=0),
+            msprime.PopulationParametersChange(time=20000, initial_size=500000, population_id=0)])
+
+_species.add_demographic_model(_valusian_empire())
+
+def _infiltration():
+    id = "Infiltration_2K29"
+    description = "Two population Valusian and infiltrator model"
+    long_description = """
+        Two populations: underground Valusians and human-disguised infiltrators.
+        Ancestral N=500000. Split 5000 gen ago. Underground at 30000.
+        Infiltrators bottleneck to 100, grow to 10000.
+    """
+    populations = [_valusia_pop, _infiltrator_pop]
+    citations = [stdpopsim.Citation(author="Kull et al.", year=1929,
+        doi="https://doi.org/10.1666/void.serpent.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=1e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=30000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=10000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=1000, initial_size=100, population_id=1),
+            msprime.MassMigration(time=5000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=5000, initial_size=500000, population_id=0)])
+
+_species.add_demographic_model(_infiltration())

--- a/stdpopsim/catalog/SerHum/genome_data.py
+++ b/stdpopsim/catalog/SerHum/genome_data.py
@@ -1,0 +1,16 @@
+data = {
+    "assembly_accession": "GCA_VOID_000018",
+    "assembly_name": "VALUSIA1.0",
+    "chromosomes": {
+        "1": {"length": 120000000, "synonyms": []},
+        "2": {"length": 110000000, "synonyms": []},
+        "3": {"length": 100000000, "synonyms": []},
+        "4": {"length": 90000000, "synonyms": []},
+        "5": {"length": 80000000, "synonyms": []},
+        "6": {"length": 70000000, "synonyms": []},
+        "7": {"length": 60000000, "synonyms": []},
+        "venom_mitogenome": {"length": 18000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/SerHum/species.py
+++ b/stdpopsim/catalog/SerHum/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Kull et al.", year=1929,
+    doi="https://doi.org/10.1666/void.serpent.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Kull et al.", year=1929,
+    doi="https://doi.org/10.1666/void.serpent.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Kull et al.", year=1929,
+    doi="https://doi.org/10.1666/void.serpent.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 1.2e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["venom_mitogenome"] = 0
+_mutation_rate = {c: 1e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["venom_mitogenome"] = 5e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["venom_mitogenome"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="SerHum", ensembl_id="serpentis_valusiensis",
+    name="Serpentis valusiensis", common_name="Serpent Person",
+    separate_sexes=True, genome=_genome, generation_time=50,
+    population_size=40000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/ShbNig/__init__.py
+++ b/stdpopsim/catalog/ShbNig/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Shubniggurath fertilitas
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/ShbNig/demographic_models.py
+++ b/stdpopsim/catalog/ShbNig/demographic_models.py
@@ -1,0 +1,68 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("ShbNig")
+
+_woods_pop = stdpopsim.Population(id="DarkWoods", description="Dark Woods breeding population")
+_cult_pop = stdpopsim.Population(id="CultBred", description="Cult-bred hybrid offspring")
+
+def _thousand_young():
+    id = "ThousandYoung_1W27"
+    description = "Explosive fertility expansion model"
+    long_description = """
+        Single population model of Shub-Niggurath's prolific reproduction.
+        Three epochs: modern explosive growth (N=100000), pre-summoning
+        bottleneck 1000 gen ago (N=500), ancient forest presence 10000
+        gen ago (N=50000).
+    """
+    populations = [_woods_pop]
+    citations = [stdpopsim.Citation(author="Whateley et al.", year=1927,
+        doi="https://doi.org/10.1666/void.shubnigg.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    generation_time = _species.generation_time
+    mutation_rate = 3e-8
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=generation_time, mutation_rate=mutation_rate,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=100000, metadata=populations[0].asdict())
+        ],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=1000, initial_size=500, population_id=0),
+            msprime.PopulationParametersChange(time=10000, initial_size=50000, population_id=0),
+        ],
+    )
+
+_species.add_demographic_model(_thousand_young())
+
+def _cult_breeding():
+    id = "CultBreeding_2W27"
+    description = "Two population woods and cult-bred model"
+    long_description = """
+        Two population model: ancient Dark Woods population and cult-bred
+        hybrids. Ancestral N=50000. Split 500 gen ago. Woods stays at
+        80000. Cult-bred founders at 20, expand to 20000.
+    """
+    populations = [_woods_pop, _cult_pop]
+    citations = [stdpopsim.Citation(author="Whateley et al.", year=1927,
+        doi="https://doi.org/10.1666/void.shubnigg.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    generation_time = _species.generation_time
+    mutation_rate = 3e-8
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=generation_time, mutation_rate=mutation_rate,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=80000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=20000, metadata=populations[1].asdict()),
+        ],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=100, initial_size=20, population_id=1),
+            msprime.MassMigration(time=500, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=500, initial_size=50000, population_id=0),
+        ],
+    )
+
+_species.add_demographic_model(_cult_breeding())

--- a/stdpopsim/catalog/ShbNig/genome_data.py
+++ b/stdpopsim/catalog/ShbNig/genome_data.py
@@ -1,0 +1,18 @@
+data = {
+    "assembly_accession": "GCA_VOID_000012",
+    "assembly_name": "DARKWOODS1.0",
+    "chromosomes": {
+        "I": {"length": 180000000, "synonyms": []},
+        "II": {"length": 165000000, "synonyms": []},
+        "III": {"length": 150000000, "synonyms": []},
+        "IV": {"length": 140000000, "synonyms": []},
+        "V": {"length": 120000000, "synonyms": []},
+        "VI": {"length": 100000000, "synonyms": []},
+        "VII": {"length": 85000000, "synonyms": []},
+        "VIII": {"length": 70000000, "synonyms": []},
+        "IX": {"length": 55000000, "synonyms": []},
+        "fertility_plasmid": {"length": 30000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/ShbNig/species.py
+++ b/stdpopsim/catalog/ShbNig/species.py
@@ -1,0 +1,51 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(
+    author="Whateley et al.",
+    year=1927,
+    doi="https://doi.org/10.1666/void.shubnigg.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+_assembly_citation = stdpopsim.Citation(
+    author="Whateley et al.", year=1927,
+    doi="https://doi.org/10.1666/void.shubnigg.2",
+    reasons={stdpopsim.CiteReason.ASSEMBLY},
+)
+_mutation_citation = stdpopsim.Citation(
+    author="Whateley et al.", year=1927,
+    doi="https://doi.org/10.1666/void.shubnigg.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE},
+)
+
+_recombination_rate = {c: 2.5e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["fertility_plasmid"] = 0
+
+_mutation_rate = {c: 3e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["fertility_plasmid"] = 1e-7
+
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["fertility_plasmid"] = 1
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[_mutation_citation, _assembly_citation],
+)
+
+_species = stdpopsim.Species(
+    id="ShbNig",
+    ensembl_id="shubniggurath_fertilitas",
+    name="Shubniggurath fertilitas",
+    common_name="Black Goat of the Woods",
+    separate_sexes=False,
+    genome=_genome,
+    generation_time=25,
+    population_size=100000,
+    ploidy=_species_ploidy,
+    citations=[_citation],
+)
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/StarSp/__init__.py
+++ b/stdpopsim/catalog/StarSp/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Starspawn cthulhidae
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/StarSp/demographic_models.py
+++ b/stdpopsim/catalog/StarSp/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("StarSp")
+_rlyeh_pop = stdpopsim.Population(id="RlyehSpawn", description="Star-Spawn in sunken R'lyeh")
+_xoth_pop = stdpopsim.Population(id="XothOrigin", description="Star-Spawn from Xoth system")
+
+def _sunken_city():
+    id = "SunkenCity_1J26"
+    description = "Single population R'lyeh entombed star-spawn model"
+    long_description = """
+        Star-Spawn entombed with Cthulhu in R'lyeh. Three epochs: modern
+        dormant (N=10000), pre-sinking golden age 2000 gen ago (N=100000),
+        arrival from Xoth 20000 gen ago (N=5000).
+    """
+    populations = [_rlyeh_pop]
+    citations = [stdpopsim.Citation(author="Johansen et al.", year=1926,
+        doi="https://doi.org/10.1666/void.starspawn.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=2e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=10000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=2000, initial_size=100000, population_id=0),
+            msprime.PopulationParametersChange(time=20000, initial_size=5000, population_id=0)])
+
+_species.add_demographic_model(_sunken_city())
+
+def _xoth_migration():
+    id = "XothMigration_2J26"
+    description = "Two population Xoth origin and R'lyeh colony model"
+    long_description = """
+        Two populations: Xoth (origin star) and R'lyeh colony. Ancestral
+        N=100000 at Xoth. Split 20000 gen ago. Xoth stable at 80000.
+        R'lyeh bottleneck to 1000, expand to 10000.
+    """
+    populations = [_xoth_pop, _rlyeh_pop]
+    citations = [stdpopsim.Citation(author="Johansen et al.", year=1926,
+        doi="https://doi.org/10.1666/void.starspawn.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=2e-9,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=80000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=10000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=1000, population_id=1),
+            msprime.MassMigration(time=20000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=20000, initial_size=100000, population_id=0)])
+
+_species.add_demographic_model(_xoth_migration())

--- a/stdpopsim/catalog/StarSp/genome_data.py
+++ b/stdpopsim/catalog/StarSp/genome_data.py
@@ -1,0 +1,14 @@
+data = {
+    "assembly_accession": "GCA_VOID_000017",
+    "assembly_name": "XOTHIC1.0",
+    "chromosomes": {
+        "I": {"length": 200000000, "synonyms": []},
+        "II": {"length": 180000000, "synonyms": []},
+        "III": {"length": 160000000, "synonyms": []},
+        "IV": {"length": 140000000, "synonyms": []},
+        "V": {"length": 120000000, "synonyms": []},
+        "spawn_organelle": {"length": 40000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/StarSp/species.py
+++ b/stdpopsim/catalog/StarSp/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Johansen et al.", year=1926,
+    doi="https://doi.org/10.1666/void.starspawn.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Johansen et al.", year=1926,
+    doi="https://doi.org/10.1666/void.starspawn.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Johansen et al.", year=1926,
+    doi="https://doi.org/10.1666/void.starspawn.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 5e-9 for c in genome_data.data["chromosomes"]}
+_recombination_rate["spawn_organelle"] = 0
+_mutation_rate = {c: 2e-9 for c in genome_data.data["chromosomes"]}
+_mutation_rate["spawn_organelle"] = 1e-8
+_species_ploidy = 4
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["spawn_organelle"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="StarSp", ensembl_id="starspawn_cthulhidae",
+    name="Starspawn cthulhidae", common_name="Star-Spawn of Cthulhu",
+    separate_sexes=False, genome=_genome, generation_time=5000,
+    population_size=10000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/TsaCho/__init__.py
+++ b/stdpopsim/catalog/TsaCho/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Tsathoggua choriensis
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/TsaCho/demographic_models.py
+++ b/stdpopsim/catalog/TsaCho/demographic_models.py
@@ -1,0 +1,172 @@
+"""
+Demographic models for Tsathoggua choriensis (Tcho-Tcho).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("TsaCho")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _plateau_tribes():
+    id = "PlateauTribes_1D33"
+    description = "Three epoch model of Tcho-Tcho plateau tribes"
+    long_description = """
+        Single population model of the Tcho-Tcho people on the plateau.
+        Three epochs: (1) a modern phase with effective population size 70000,
+        (2) a persecution decline beginning 500 generations ago with N=20000,
+        and (3) an ancient empire era beginning 5000 generations ago with
+        N=200000. Based on the studies of Derleth et al. (1933).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="TchoTcho",
+            description="Tcho-Tcho -- degenerate human-like tribe serving dark gods",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=70000
+    # Persecution decline at T=500 gen: N=20000
+    # Ancient empire at T=5000 gen: N=200000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=70000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=500,
+            initial_size=20000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=200000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=25,
+        mutation_rate=1.5e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_plateau_tribes())
+
+
+def _tainted_lineage():
+    id = "TaintedLineage_2D33"
+    description = "Two population model of Highland Tribes and Lowland Infiltrator Tcho-Tcho"
+    long_description = """
+        Two population model describing the divergence of Highland Tribes and
+        Lowland Infiltrator Tcho-Tcho populations. The ancestral population of
+        size 200000 splits at 2000 generations ago. The Highland Tribe
+        population maintains a size of 70000. The Lowland Infiltrator lineage
+        goes through a bottleneck of 500 individuals before expanding to
+        30000. Based on Derleth et al. (1933).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="HighlandTribes",
+            description="Highland Tribes -- traditional Tcho-Tcho plateau dwellers",
+        ),
+        stdpopsim.Population(
+            id="LowlandInfiltrators",
+            description="Lowland Infiltrators -- Tcho-Tcho dispersed among humans",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: HighlandTribes N=70000, LowlandInfiltrators N=30000
+    # At T=500 gen ago: LowlandInfiltrators bottleneck N=500
+    # At T=2000 gen ago: populations merge into ancestral pop N=200000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=70000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=30000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Lowland Infiltrator bottleneck at 500 generations ago
+        msprime.PopulationParametersChange(
+            time=500,
+            initial_size=500,
+            population_id=1,
+        ),
+        # At 2000 generations ago, the two populations merge
+        msprime.MassMigration(
+            time=2000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=2000,
+            initial_size=200000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=25,
+        mutation_rate=1.5e-8,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_tainted_lineage())

--- a/stdpopsim/catalog/TsaCho/genome_data.py
+++ b/stdpopsim/catalog/TsaCho/genome_data.py
@@ -1,0 +1,46 @@
+# Genome data for Tsathoggua choriensis (Tcho-Tcho)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000030",
+    "assembly_name": "PLATEAU1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "1": {
+            "length": 130000000,
+            "synonyms": ["chr1", "tainted_1"],
+        },
+        "2": {
+            "length": 118000000,
+            "synonyms": ["chr2", "tainted_2"],
+        },
+        "3": {
+            "length": 105000000,
+            "synonyms": ["chr3", "tainted_3"],
+        },
+        "4": {
+            "length": 92000000,
+            "synonyms": ["chr4", "tainted_4"],
+        },
+        "5": {
+            "length": 80000000,
+            "synonyms": ["chr5", "tainted_5"],
+        },
+        "6": {
+            "length": 68000000,
+            "synonyms": ["chr6", "tainted_6"],
+        },
+        "7": {
+            "length": 58000000,
+            "synonyms": ["chr7", "tainted_7"],
+        },
+        "8": {
+            "length": 50000000,
+            "synonyms": ["chr8", "tainted_8"],
+        },
+        "tainted_mitogenome": {
+            "length": 16500,
+            "synonyms": ["mt", "dark_mt"],
+        },
+    },
+}

--- a/stdpopsim/catalog/TsaCho/species.py
+++ b/stdpopsim/catalog/TsaCho/species.py
@@ -1,0 +1,107 @@
+"""
+Species definition for Tsathoggua choriensis (Tcho-Tcho).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Tcho-Tcho have elevated recombination reflecting their
+# rapid generational turnover and tainted genomic architecture.
+# Tainted mitogenome does not recombine.
+_recombination_rate = {
+    "1": 1.2e-8,
+    "2": 1.2e-8,
+    "3": 1.2e-8,
+    "4": 1.2e-8,
+    "5": 1.2e-8,
+    "6": 1.2e-8,
+    "7": 1.2e-8,
+    "8": 1.2e-8,
+    "tainted_mitogenome": 0,
+}
+
+# Mutation rates per chromosome.
+# Elevated mutation rate for degenerate human-like tribe.
+_mutation_rate = {
+    "1": 1.5e-8,
+    "2": 1.5e-8,
+    "3": 1.5e-8,
+    "4": 1.5e-8,
+    "5": 1.5e-8,
+    "6": 1.5e-8,
+    "7": 1.5e-8,
+    "8": 1.5e-8,
+    "tainted_mitogenome": 1.5e-8,
+}
+
+# Ploidy: diploid for main chromosomes, haploid for tainted mitogenome.
+_species_ploidy = 2
+_ploidy = {
+    "1": _species_ploidy,
+    "2": _species_ploidy,
+    "3": _species_ploidy,
+    "4": _species_ploidy,
+    "5": _species_ploidy,
+    "6": _species_ploidy,
+    "7": _species_ploidy,
+    "8": _species_ploidy,
+    "tainted_mitogenome": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="TsaCho",
+    ensembl_id="tsathoggua_choriensis",
+    name="Tsathoggua choriensis",
+    common_name="Tcho-Tcho",
+    genome=_genome,
+    generation_time=25,
+    population_size=70000,
+    ploidy=_species_ploidy,
+    separate_sexes=True,
+    citations=[
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Derleth et al.",
+            year=1933,
+            doi="https://doi.org/10.1666/void.tsacho.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/TsaGod/__init__.py
+++ b/stdpopsim/catalog/TsaGod/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Tsathoggua somnolentis
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/TsaGod/demographic_models.py
+++ b/stdpopsim/catalog/TsaGod/demographic_models.py
@@ -1,0 +1,174 @@
+"""
+Demographic models for Tsathoggua somnolentis (Tsathoggua).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("TsaGod")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _slothful_dormancy():
+    id = "SlothfulDormancy_1S31"
+    description = "Cyclic dormancy model for Tsathoggua in N'kai"
+    long_description = """
+        Single population model of Tsathoggua's slothful dormancy in the
+        caverns of N'kai. Three epochs: (1) a modern phase with effective
+        population size 100, (2) a brief awakening period beginning 500
+        generations ago with N=1000, and (3) a deep slumber era beginning
+        5000 generations ago with N=10. Based on the work of Smith et al.
+        (1931).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="Nkai",
+            description="N'kai cavern dwellers -- Tsathoggua and kin",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=100
+    # Brief awakening at T=500 gen: N=1000
+    # Deep slumber at T=5000 gen: N=10
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=100,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=500,
+            initial_size=1000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=10,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=50000,
+        mutation_rate=5e-10,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_slothful_dormancy())
+
+
+def _nkai_caverns():
+    id = "NkaiCaverns_2S31"
+    description = "Two population model of N'kai Depths and Surface Avatars"
+    long_description = """
+        Two population model describing the divergence of the N'kai Depths
+        dwellers and Surface Avatars. The ancestral population of size 1000
+        splits at 200 generations ago. The N'kai population maintains a size
+        of 100. The Surface Avatar lineage goes through a bottleneck of 5
+        individuals before expanding to 50. Based on the work of Smith et al.
+        (1931).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="NkaiDepths",
+            description="N'kai Depths -- deep cavern dwellers",
+        ),
+        stdpopsim.Population(
+            id="SurfaceAvatars",
+            description="Surface Avatars -- terrestrial manifestations",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: NkaiDepths N=100, SurfaceAvatars N=50
+    # At T=100 gen ago: SurfaceAvatars bottleneck N=5
+    # At T=200 gen ago: populations merge into ancestral pop N=1000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=100,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=50,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Surface Avatar bottleneck
+        msprime.PopulationParametersChange(
+            time=100,
+            initial_size=5,
+            population_id=1,
+        ),
+        # At 200 generations ago, the two populations merge
+        # (SurfaceAvatars merge into NkaiDepths going backwards in time)
+        msprime.MassMigration(
+            time=200,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=200,
+            initial_size=1000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=50000,
+        mutation_rate=5e-10,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_nkai_caverns())

--- a/stdpopsim/catalog/TsaGod/genome_data.py
+++ b/stdpopsim/catalog/TsaGod/genome_data.py
@@ -1,0 +1,30 @@
+# Genome data for Tsathoggua somnolentis (Tsathoggua)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000031",
+    "assembly_name": "NKAI1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 250000000,
+            "synonyms": ["chr1", "toad_segment_1"],
+        },
+        "II": {
+            "length": 200000000,
+            "synonyms": ["chr2", "toad_segment_2"],
+        },
+        "III": {
+            "length": 150000000,
+            "synonyms": ["chr3", "sloth_segment"],
+        },
+        "IV": {
+            "length": 100000000,
+            "synonyms": ["chr4", "cavern_segment"],
+        },
+        "nkai_plasmid": {
+            "length": 30000,
+            "synonyms": ["mt", "nkai_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/TsaGod/species.py
+++ b/stdpopsim/catalog/TsaGod/species.py
@@ -1,0 +1,95 @@
+"""
+Species definition for Tsathoggua somnolentis (Tsathoggua).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# Tsathoggua's toad-like genome has very low recombination,
+# reflecting eons of slothful dormancy in N'kai.
+# N'kai plasmid does not recombine.
+_recombination_rate = {
+    "I": 3e-10,
+    "II": 3e-10,
+    "III": 3e-10,
+    "IV": 3e-10,
+    "nkai_plasmid": 0,
+}
+
+# Mutation rates per chromosome.
+# Extremely stable alien genome with very low mutation rate.
+_mutation_rate = {
+    "I": 5e-10,
+    "II": 5e-10,
+    "III": 5e-10,
+    "IV": 5e-10,
+    "nkai_plasmid": 5e-10,
+}
+
+# Ploidy: diploid for the main chromosomes, haploid for nkai plasmid.
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "nkai_plasmid": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="TsaGod",
+    ensembl_id="tsathoggua_somnolentis",
+    name="Tsathoggua somnolentis",
+    common_name="Tsathoggua",
+    genome=_genome,
+    generation_time=50000,
+    population_size=100,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=[
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Smith et al.",
+            year=1931,
+            doi="https://doi.org/10.1666/void.tsathoggua.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/WamUnd/__init__.py
+++ b/stdpopsim/catalog/WamUnd/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Degeneratus subterraneus
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/WamUnd/demographic_models.py
+++ b/stdpopsim/catalog/WamUnd/demographic_models.py
@@ -1,0 +1,187 @@
+"""
+Demographic models for Degeneratus subterraneus (Wamp).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+
+import stdpopsim
+
+_species = stdpopsim.get_species("WamUnd")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+# Fictional citations for stdvoidsim
+
+_martense_et_al = stdpopsim.Citation(
+    author="Martense et al.",
+    year=1922,
+    doi="https://doi.org/10.1666/void.wamp.demog.1",
+    reasons={stdpopsim.CiteReason.DEM_MODEL},
+)
+
+
+# -------------------------------------------------------------------------
+# MartenseDegeneration_1M22: Single population three-epoch model
+# -------------------------------------------------------------------------
+
+
+def _martense_degeneration():
+    id = "MartenseDegeneration_1M22"
+    description = "Single population three-epoch model of Wamp degeneration"
+    long_description = """
+        Single population model of Wamp demographic history. Three epochs:
+        modern subterranean population with effective population size 20,000,
+        a split from surface humanity beginning 500 generations ago with
+        severe bottleneck N=50, and the ancestral Martense family era
+        beginning 600 generations ago with N=5,000. Based on the Catskill
+        investigations of Martense et al. (1922).
+    """
+    citations = [_martense_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="Wamps",
+            description="Wamps of the Catskill mountain warrens",
+        ),
+    ]
+
+    # Modern subterranean: N=20,000
+    # Surface split bottleneck at T=500 gen: N=50
+    # Ancestral Martense family at T=600 gen: N=5,000
+    N_modern = 20000
+    N_bottleneck = 50
+    N_ancestral = 5000
+
+    T_split = 500
+    T_ancestral = 600
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_modern,
+            metadata={
+                "name": "Wamps",
+                "description": "Wamps of the Catskill mountain warrens",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_bottleneck, population_id=0
+        ),
+        msprime.PopulationParametersChange(
+            time=T_ancestral, initial_size=N_ancestral, population_id=0
+        ),
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10,
+        mutation_rate=3e-8,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=[[0]],
+    )
+
+
+_species.add_demographic_model(_martense_degeneration())
+
+
+# -------------------------------------------------------------------------
+# CatskillWarrens_2M22: Two population model
+# -------------------------------------------------------------------------
+
+
+def _catskill_warrens():
+    id = "CatskillWarrens_2M22"
+    description = "Two-population model of Deep Warrens and Surface Raids Wamps"
+    long_description = """
+        Two-population model representing Deep Warrens Wamps and Surface
+        Raids Wamps. An ancestral population of size 5,000 splits at
+        300 generations ago. The Deep Warrens population maintains a
+        size of 20,000. The Surface Raids lineage goes through a
+        bottleneck of 30 individuals before expanding to 3,000 in the
+        present day. Based on the Catskill investigations of Martense
+        et al. (1922).
+    """
+    citations = [_martense_et_al]
+
+    populations = [
+        stdpopsim.Population(
+            id="DeepWarrens",
+            description="Deep Warrens Wamps -- permanent subterranean dwellers",
+        ),
+        stdpopsim.Population(
+            id="SurfaceRaids",
+            description="Surface Raids Wamps -- nocturnal surface predators",
+        ),
+    ]
+
+    # Parameters
+    N_ancestral = 5000
+    N_warrens = 20000
+    N_surface_modern = 3000
+    N_surface_bottleneck = 30
+    T_split = 300
+
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=N_warrens,
+            metadata={
+                "name": "DeepWarrens",
+                "description": "Deep Warrens Wamps -- permanent subterranean dwellers",
+            },
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=N_surface_modern,
+            metadata={
+                "name": "SurfaceRaids",
+                "description": "Surface Raids Wamps -- nocturnal surface predators",
+            },
+        ),
+    ]
+
+    demographic_events = [
+        # Surface Raids bottleneck right after the split
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_surface_bottleneck, population_id=1
+        ),
+        # Split: Surface Raids merge back into Deep Warrens at T_split
+        msprime.MassMigration(
+            time=T_split, source=1, destination=0, proportion=1.0
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=T_split, initial_size=N_ancestral, population_id=0
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=10,
+        mutation_rate=3e-8,
+        population_configurations=population_configurations,
+        demographic_events=demographic_events,
+        migration_matrix=migration_matrix,
+    )
+
+
+_species.add_demographic_model(_catskill_warrens())

--- a/stdpopsim/catalog/WamUnd/genome_data.py
+++ b/stdpopsim/catalog/WamUnd/genome_data.py
@@ -1,0 +1,46 @@
+# Genome data for Degeneratus subterraneus (Wamp)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000038",
+    "assembly_name": "CATSKILL1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "1": {
+            "length": 80000000,
+            "synonyms": ["chr1", "tunnel_segment_1"],
+        },
+        "2": {
+            "length": 70000000,
+            "synonyms": ["chr2", "tunnel_segment_2"],
+        },
+        "3": {
+            "length": 60000000,
+            "synonyms": ["chr3", "claw_arm"],
+        },
+        "4": {
+            "length": 55000000,
+            "synonyms": ["chr4", "jaw_segment"],
+        },
+        "5": {
+            "length": 50000000,
+            "synonyms": ["chr5", "night_eye"],
+        },
+        "6": {
+            "length": 45000000,
+            "synonyms": ["chr6", "burrow_sense"],
+        },
+        "7": {
+            "length": 35000000,
+            "synonyms": ["chr7", "degenerate_limb"],
+        },
+        "8": {
+            "length": 30000000,
+            "synonyms": ["chr8", "vestigial_cortex"],
+        },
+        "degenerate_mitogenome": {
+            "length": 15000,
+            "synonyms": ["mt", "degenerate_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/WamUnd/species.py
+++ b/stdpopsim/catalog/WamUnd/species.py
@@ -1,0 +1,70 @@
+"""
+Species definition for Degeneratus subterraneus (Wamp).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Fictional citations for stdvoidsim
+
+_martense_et_al = stdpopsim.Citation(
+    author="Martense et al.",
+    year=1922,
+    doi="https://doi.org/10.1666/void.wamp.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE},
+)
+
+_martense_genome_ref = stdpopsim.Citation(
+    author="Martense et al.",
+    year=1922,
+    doi="https://doi.org/10.1666/void.wamp.assembly.1",
+    reasons={
+        stdpopsim.CiteReason.ASSEMBLY,
+        stdpopsim.CiteReason.MUT_RATE,
+        stdpopsim.CiteReason.REC_RATE,
+    },
+)
+
+_genome_citations = [_martense_genome_ref]
+_species_citations = [_martense_et_al, _martense_genome_ref]
+
+# Chromosome-level mutation rate (~3e-8 per base per generation)
+# High due to inbreeding-accelerated mutation accumulation
+_overall_mutation_rate = 3e-8
+
+# Chromosome-level recombination rate (~2e-8 per base per generation)
+_overall_recombination_rate = 2e-8
+
+_chromosome_names = list(genome_data.data["chromosomes"].keys())
+
+_mutation_rate = {name: _overall_mutation_rate for name in _chromosome_names}
+
+_recombination_rate = {name: _overall_recombination_rate for name in _chromosome_names}
+
+# Ploidy of 2 for all chromosomes (diploid)
+_ploidy = {name: 2 for name in _chromosome_names}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=_genome_citations,
+)
+
+_species = stdpopsim.Species(
+    id="WamUnd",
+    ensembl_id="degeneratus_subterraneus",
+    name="Degeneratus subterraneus",
+    common_name="Wamp",
+    genome=_genome,
+    generation_time=10,
+    population_size=20000,
+    ploidy=2,
+    separate_sexes=True,
+    citations=_species_citations,
+)
+
+stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/YitGre/__init__.py
+++ b/stdpopsim/catalog/YitGre/__init__.py
@@ -1,0 +1,6 @@
+"""
+Catalog data for Yithianus temporalis
+"""
+
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/YitGre/demographic_models.py
+++ b/stdpopsim/catalog/YitGre/demographic_models.py
@@ -1,0 +1,172 @@
+"""
+Demographic models for Yithianus temporalis (Great Race of Yith).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("YitGre")
+
+###########################################################################
+#
+# Demographic models
+#
+###########################################################################
+
+
+def _temporal_migration():
+    id = "TemporalMigration_1P35"
+    description = "Three epoch model of Great Race of Yith temporal migration"
+    long_description = """
+        Single population model of the Great Race of Yith in Pnakotus.
+        Three epochs: (1) a modern phase with effective population size 50000,
+        (2) a post-polyp-war bottleneck beginning 5000 generations ago with
+        N=10000, and (3) a golden library age beginning 50000 generations ago
+        with N=500000. Based on the studies of Peaslee et al. (1935).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="Yithians",
+            description="Yithians -- cone-shaped time-traveling entities",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.demog.1",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Modern phase: N=50000
+    # Post-polyp-war bottleneck at T=5000 gen: N=10000
+    # Golden library age at T=50000 gen: N=500000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=50000,
+            metadata=populations[0].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=10000,
+            population_id=0,
+        ),
+        msprime.PopulationParametersChange(
+            time=50000,
+            initial_size=500000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [[0]]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=500,
+        mutation_rate=3e-9,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_temporal_migration())
+
+
+def _conic_mind_swap():
+    id = "ConicMindSwap_2P35"
+    description = "Two population model of Pnakotus City and Remote Outpost Yithians"
+    long_description = """
+        Two population model describing the divergence of Pnakotus City and
+        Remote Outpost Yithian populations. The ancestral population of size
+        500000 splits at 20000 generations ago. The Pnakotus City population
+        maintains a size of 50000. The Remote Outpost lineage goes through a
+        bottleneck of 500 individuals before expanding to 20000. Based on
+        Peaslee et al. (1935).
+    """
+    populations = [
+        stdpopsim.Population(
+            id="PnakotusCity",
+            description="Pnakotus City -- central Yithian civilization",
+        ),
+        stdpopsim.Population(
+            id="RemoteOutposts",
+            description="Remote Outposts -- peripheral Yithian settlements",
+        ),
+    ]
+
+    citations = [
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.demog.2",
+            reasons={stdpopsim.CiteReason.DEM_MODEL},
+        ),
+    ]
+
+    # Present day: PnakotusCity N=50000, RemoteOutposts N=20000
+    # At T=5000 gen ago: RemoteOutposts bottleneck N=500
+    # At T=20000 gen ago: populations merge into ancestral pop N=500000
+    population_configurations = [
+        msprime.PopulationConfiguration(
+            initial_size=50000,
+            metadata=populations[0].asdict(),
+        ),
+        msprime.PopulationConfiguration(
+            initial_size=20000,
+            metadata=populations[1].asdict(),
+        ),
+    ]
+
+    demographic_events = [
+        # Remote Outpost bottleneck at 5000 generations ago
+        msprime.PopulationParametersChange(
+            time=5000,
+            initial_size=500,
+            population_id=1,
+        ),
+        # At 20000 generations ago, the two populations merge
+        msprime.MassMigration(
+            time=20000,
+            source=1,
+            destination=0,
+            proportion=1.0,
+        ),
+        # Ancestral population size
+        msprime.PopulationParametersChange(
+            time=20000,
+            initial_size=500000,
+            population_id=0,
+        ),
+    ]
+
+    migration_matrix = [
+        [0, 0],
+        [0, 0],
+    ]
+
+    return stdpopsim.DemographicModel(
+        id=id,
+        description=description,
+        long_description=long_description,
+        populations=populations,
+        citations=citations,
+        generation_time=500,
+        mutation_rate=3e-9,
+        population_configurations=population_configurations,
+        migration_matrix=migration_matrix,
+        demographic_events=demographic_events,
+    )
+
+
+_species.add_demographic_model(_conic_mind_swap())

--- a/stdpopsim/catalog/YitGre/genome_data.py
+++ b/stdpopsim/catalog/YitGre/genome_data.py
@@ -1,0 +1,42 @@
+# Genome data for Yithianus temporalis (Great Race of Yith)
+# Fictional genome assembly for the stdvoidsim project.
+data = {
+    "assembly_accession": "GCA_VOID_000029",
+    "assembly_name": "PNAKOTUS1.0",
+    "assembly_source": "manual",
+    "assembly_build_version": None,
+    "chromosomes": {
+        "I": {
+            "length": 150000000,
+            "synonyms": ["chr1", "cone_1"],
+        },
+        "II": {
+            "length": 130000000,
+            "synonyms": ["chr2", "cone_2"],
+        },
+        "III": {
+            "length": 110000000,
+            "synonyms": ["chr3", "cone_3"],
+        },
+        "IV": {
+            "length": 95000000,
+            "synonyms": ["chr4", "cone_4"],
+        },
+        "V": {
+            "length": 80000000,
+            "synonyms": ["chr5", "cone_5"],
+        },
+        "VI": {
+            "length": 65000000,
+            "synonyms": ["chr6", "cone_6"],
+        },
+        "VII": {
+            "length": 50000000,
+            "synonyms": ["chr7", "cone_7"],
+        },
+        "temporal_organelle": {
+            "length": 45000,
+            "synonyms": ["mt", "time_organelle"],
+        },
+    },
+}

--- a/stdpopsim/catalog/YitGre/species.py
+++ b/stdpopsim/catalog/YitGre/species.py
@@ -1,0 +1,104 @@
+"""
+Species definition for Yithianus temporalis (Great Race of Yith).
+Part of the stdvoidsim project -- a fictional species catalog.
+"""
+
+import stdpopsim
+
+from . import genome_data
+
+# Recombination rates per chromosome.
+# The Great Race of Yith has very low recombination reflecting
+# their extremely stable time-spanning genomic architecture.
+# Temporal organelle does not recombine.
+_recombination_rate = {
+    "I": 2e-9,
+    "II": 2e-9,
+    "III": 2e-9,
+    "IV": 2e-9,
+    "V": 2e-9,
+    "VI": 2e-9,
+    "VII": 2e-9,
+    "temporal_organelle": 0,
+}
+
+# Mutation rates per chromosome.
+# Low mutation rate for long-lived cone-shaped entities.
+_mutation_rate = {
+    "I": 3e-9,
+    "II": 3e-9,
+    "III": 3e-9,
+    "IV": 3e-9,
+    "V": 3e-9,
+    "VI": 3e-9,
+    "VII": 3e-9,
+    "temporal_organelle": 3e-9,
+}
+
+# Ploidy: diploid for main chromosomes, haploid for temporal organelle.
+_species_ploidy = 2
+_ploidy = {
+    "I": _species_ploidy,
+    "II": _species_ploidy,
+    "III": _species_ploidy,
+    "IV": _species_ploidy,
+    "V": _species_ploidy,
+    "VI": _species_ploidy,
+    "VII": _species_ploidy,
+    "temporal_organelle": 1,
+}
+
+_genome = stdpopsim.Genome.from_data(
+    genome_data.data,
+    recombination_rate=_recombination_rate,
+    mutation_rate=_mutation_rate,
+    ploidy=_ploidy,
+    citations=[
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.1",
+            reasons={stdpopsim.CiteReason.MUT_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.2",
+            reasons={stdpopsim.CiteReason.REC_RATE},
+        ),
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.3",
+            reasons={stdpopsim.CiteReason.ASSEMBLY},
+        ),
+    ],
+)
+
+_species = stdpopsim.Species(
+    id="YitGre",
+    ensembl_id="yithianus_temporalis",
+    name="Yithianus temporalis",
+    common_name="Great Race of Yith",
+    genome=_genome,
+    generation_time=500,
+    population_size=50000,
+    ploidy=_species_ploidy,
+    separate_sexes=False,
+    citations=[
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.4",
+            reasons={stdpopsim.CiteReason.GEN_TIME},
+        ),
+        stdpopsim.Citation(
+            author="Peaslee et al.",
+            year=1935,
+            doi="https://doi.org/10.1666/void.yitgre.5",
+            reasons={stdpopsim.CiteReason.POP_SIZE},
+        ),
+    ],
+)
+
+stdpopsim.species.register_species(_species)

--- a/stdpopsim/catalog/ZooGul/__init__.py
+++ b/stdpopsim/catalog/ZooGul/__init__.py
@@ -1,0 +1,5 @@
+"""
+Catalog data for Zoogus sylvaticus
+"""
+from . import species  # noqa: F401
+from . import demographic_models  # noqa: F401

--- a/stdpopsim/catalog/ZooGul/demographic_models.py
+++ b/stdpopsim/catalog/ZooGul/demographic_models.py
@@ -1,0 +1,56 @@
+import msprime
+import stdpopsim
+
+_species = stdpopsim.get_species("ZooGul")
+_enchanted_pop = stdpopsim.Population(id="EnchantedWood", description="Zoogs of the Enchanted Wood")
+_upper_pop = stdpopsim.Population(id="UpperDreamlands", description="Upper Dreamlands zoog colony")
+
+def _enchanted_wood():
+    id = "EnchantedWood_1C26"
+    description = "Single population Enchanted Wood zoog model"
+    long_description = """
+        Single population in Enchanted Wood. Three epochs: modern
+        thriving (N=500000), cat-war bottleneck 10000 gen ago (N=50000),
+        ancient forest founding 100000 gen ago (N=200000).
+    """
+    populations = [_enchanted_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.zoog.dem1",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=2.5e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=500000, metadata=populations[0].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=10000, initial_size=50000, population_id=0),
+            msprime.PopulationParametersChange(time=100000, initial_size=200000, population_id=0)])
+
+_species.add_demographic_model(_enchanted_wood())
+
+def _dreamlands_spread():
+    id = "DreamlandsSpread_2C26"
+    description = "Two population Enchanted Wood and upper Dreamlands model"
+    long_description = """
+        Two populations: Enchanted Wood core and upper Dreamlands colony.
+        Ancestral N=200000. Split 30000 gen ago. Wood at 500000. Upper
+        bottleneck to 1000, grow to 100000.
+    """
+    populations = [_enchanted_pop, _upper_pop]
+    citations = [stdpopsim.Citation(author="Carter et al.", year=1926,
+        doi="https://doi.org/10.1666/void.zoog.dem2",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})]
+    return stdpopsim.DemographicModel(
+        id=id, description=description, long_description=long_description,
+        populations=populations, citations=citations,
+        generation_time=_species.generation_time, mutation_rate=2.5e-8,
+        population_configurations=[
+            msprime.PopulationConfiguration(initial_size=500000, metadata=populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=100000, metadata=populations[1].asdict())],
+        demographic_events=[
+            msprime.PopulationParametersChange(time=5000, initial_size=1000, population_id=1),
+            msprime.MassMigration(time=30000, source=1, destination=0, proportion=1.0),
+            msprime.PopulationParametersChange(time=30000, initial_size=200000, population_id=0)])
+
+_species.add_demographic_model(_dreamlands_spread())

--- a/stdpopsim/catalog/ZooGul/genome_data.py
+++ b/stdpopsim/catalog/ZooGul/genome_data.py
@@ -1,0 +1,14 @@
+data = {
+    "assembly_accession": "GCA_VOID_000022",
+    "assembly_name": "ENCHANTED1.0",
+    "chromosomes": {
+        "1": {"length": 25000000, "synonyms": []},
+        "2": {"length": 22000000, "synonyms": []},
+        "3": {"length": 20000000, "synonyms": []},
+        "4": {"length": 18000000, "synonyms": []},
+        "5": {"length": 15000000, "synonyms": []},
+        "forest_mitogenome": {"length": 16000, "synonyms": []},
+    },
+    "assembly_source": "void_archives",
+    "assembly_build_version": "1",
+}

--- a/stdpopsim/catalog/ZooGul/species.py
+++ b/stdpopsim/catalog/ZooGul/species.py
@@ -1,0 +1,29 @@
+import stdpopsim
+from . import genome_data
+
+_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.zoog.1",
+    reasons={stdpopsim.CiteReason.GEN_TIME, stdpopsim.CiteReason.POP_SIZE})
+_assembly_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.zoog.2", reasons={stdpopsim.CiteReason.ASSEMBLY})
+_mutation_citation = stdpopsim.Citation(author="Carter et al.", year=1926,
+    doi="https://doi.org/10.1666/void.zoog.3",
+    reasons={stdpopsim.CiteReason.MUT_RATE, stdpopsim.CiteReason.REC_RATE})
+
+_recombination_rate = {c: 3e-8 for c in genome_data.data["chromosomes"]}
+_recombination_rate["forest_mitogenome"] = 0
+_mutation_rate = {c: 2.5e-8 for c in genome_data.data["chromosomes"]}
+_mutation_rate["forest_mitogenome"] = 8e-8
+_species_ploidy = 2
+_ploidy = {c: _species_ploidy for c in genome_data.data["chromosomes"]}
+_ploidy["forest_mitogenome"] = 1
+
+_genome = stdpopsim.Genome.from_data(genome_data.data,
+    recombination_rate=_recombination_rate, mutation_rate=_mutation_rate,
+    ploidy=_ploidy, citations=[_mutation_citation, _assembly_citation])
+
+_species = stdpopsim.Species(id="ZooGul", ensembl_id="zoogus_sylvaticus",
+    name="Zoogus sylvaticus", common_name="Zoog",
+    separate_sexes=True, genome=_genome, generation_time=2,
+    population_size=500000, ploidy=_species_ploidy, citations=[_citation])
+stdpopsim.register_species(_species)


### PR DESCRIPTION
Expands the stdvoidsim catalog from 10 to 40 species covering the full Lovecraft bestiary: Outer Gods, Great Old Ones, Servitor Races, Ancient Civilizations, Aquatic/Subterranean/Dreamlands creatures, and more. Each species has unique genome parameters and two demographic models. Updates README, catalog, and introduction docs.

https://claude.ai/code/session_01RqGVNKSy4tdD8Y32FsUCha