### PR TITLE
Fix .readthedocs.yml: add required build.os and tools config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-22.9"
+
 sphinx:
   builder: html
   configuration: docs/conf.py


### PR DESCRIPTION
RTD v2 config requires build.os. Use ubuntu-22.04 with mambaforge for conda environment support.

https://claude.ai/code/session_01RqGVNKSy4tdD8Y32FsUCha