### PR TITLE
Fix RTD build: upgrade Python to 3.12 and update conda deps

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-22.9"
+    python: "mambaforge-24.7"
 
 sphinx:
   builder: html

--- a/requirements/rtd-conda-environment.yml
+++ b/requirements/rtd-conda-environment.yml
@@ -1,23 +1,15 @@
-name: stdpopsim-rtd
+name: stdvoidsim-rtd
 
 channels:
   - conda-forge
   - bioconda
 
 dependencies:
-  - _libgcc_mutex=0.1
-  - _openmp_mutex=4.5
-  - gsl=2.6
-  - libblas=3.8.0
-  - libcblas=3.8.0
-  - libgcc-ng=9.2.0
-  - libgfortran-ng=7.3.0
-  - libopenblas=0.3.9
-  - llvm-openmp=10.0.0
-  - python=3.8
-  - sphinx-argparse=0.2.5
-  - sphinx-issues=1.2.0
-  - sphinxcontrib-programoutput=0.16
+  - python=3.12
+  - gsl
   - scipy
-  - demes==0.1.2
-  - demesdraw==0.1.4
+  - sphinx-argparse
+  - sphinx-issues
+  - sphinxcontrib-programoutput
+  - demes
+  - demesdraw


### PR DESCRIPTION
The package requires Python >=3.10 but the conda env had 3.8. Removed pinned system library versions, updated mambaforge version.

https://claude.ai/code/session_01RqGVNKSy4tdD8Y32FsUCha